### PR TITLE
Add font fix for hi_IN/mr .widget-title

### DIFF
--- a/.dev/sass/common/_variables.scss
+++ b/.dev/sass/common/_variables.scss
@@ -16,6 +16,7 @@ $medium-up: "only screen and (min-width: #{$medium-screen})";
 $medium-down: "only screen and (max-width: #{$large-screen})";
 $medium-only: "only screen and (min-width: #{$medium-screen}) and (max-width: #{$large-screen})";
 $large-up: "only screen and (min-width: #{$large-screen})";
+$webkit: "screen and (-webkit-min-device-pixel-ratio:0)";
 
 // Typography
 $font__main: $primary-font, "Helvetica Neue", sans-serif;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -116,3 +116,12 @@
 		width: auto;
 	}
 }
+
+@media #{$webkit} {
+
+	html :lang(hi) h2.widget-title,
+	html :lang(mr) h2.widget-title {
+		font-family: -webkit-body;
+	}
+
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1760,6 +1760,11 @@ body.no-max-width .page-title-container .page-header {
     display: inline;
     width: auto; }
 
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  html :lang(hi) h2.widget-title,
+  html :lang(mr) h2.widget-title {
+    font-family: -webkit-body; } }
+
 /*--------------------------------------------------------------
 # Footer
 --------------------------------------------------------------*/

--- a/style.css
+++ b/style.css
@@ -1760,6 +1760,11 @@ body.no-max-width .page-title-container .page-header {
     display: inline;
     width: auto; }
 
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  html :lang(hi) h2.widget-title,
+  html :lang(mr) h2.widget-title {
+    font-family: -webkit-body; } }
+
 /*--------------------------------------------------------------
 # Footer
 --------------------------------------------------------------*/


### PR DESCRIPTION
Related: https://github.com/godaddy/wp-stout-theme/pull/27

Two languages were not rendering properly in the header of Velux. This bug affects both Chrome and IE.

See: https://jira.godaddy.com/browse/WPDEV-667

Through some exhaustive testing I went through and tested Velux against all bundled languages within [Primer](https://github.com/godaddy/wp-primer-theme/tree/develop/languages). I found that the only two problems were in the rendering of `hi_IN` and `mr`.

Problem languages:
- hi_IN
- mr