### PR TITLE
Prevent i10n button overlaps, remove on sale comment, adjust font size for WooCommerce compat.

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -172,6 +172,10 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 }
 
+.woocommerce a.added_to_cart {
+	text-align: left;
+}
+
 body.post-type-archive,
 body.single-product {
 	span.onsale,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -159,9 +159,21 @@
 	}
 }
 
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+	max-width: 100%;
+	white-space: normal;
+	text-align: center;
+	display: block;
+
+	@media #{$large-up} {
+		font-size: 0.75rem;
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -197,6 +197,16 @@
 		background-color: transparent;
 	}
 
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
 	#reviews #comments ol.commentlist li {
 
 		img.avatar {
@@ -250,19 +260,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
 	text-align: left;
-}
-
-body.post-type-archive,
-body.single-product {
-	span.onsale,
-	ul.products li.product .onsale {
-		padding: 2px 8px;
-		border-radius: 0;
-		margin: 0;
-		min-height: auto;
-		min-width: auto;
-		line-height: inherit;
-	}
 }
 
 body.single-product {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -283,6 +283,7 @@ body.woocommerce-cart {
 .woocommerce ul.products li.product a.add_to_cart_button {
 	width: 100%;
 	text-align: center;
+	white-space: normal;
 }
 
 @media #{$small-only} {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -159,6 +159,82 @@
 	}
 }
 
+.woocommerce-page {
+
+	div.product {
+
+		.woocommerce-product-gallery {
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		.summary {
+			margin-top: 0;
+		}
+
+		.commentlist {
+			padding-left: 0;
+		}
+
+	}
+
+	&.woocommerce div.product form.cart {
+		margin: 1em 0;
+	}
+
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
+
+	.primer-woocommerce .cart .qty {
+		padding: 0.4em;
+	}
+
+	table.variations tr:hover td {
+		background-color: transparent;
+	}
+
+	#reviews #comments ol.commentlist li {
+
+		img.avatar {
+			width: 60px;
+		}
+
+		.comment-text {
+			margin: 0 0 0 80px;
+		}
+
+	}
+
+	form.woocommerce-cart-form {
+
+		table.cart td.actions #coupon_code {
+			width: 50%;
+			margin-right: 0;
+
+		}
+
+	}
+
+	table.cart {
+
+		img {
+			width: 100%;
+			max-width: 75px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 10px !important;
+		}
+
+	}
+
+}
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
 	max-width: 100%;
@@ -204,21 +280,6 @@ body.single-product {
 body.woocommerce-cart {
 	.primer-wc-cart-sub-menu {
 		display: none;
-	}
-}
-
-.woocommerce,
-.woocommerce-page {
-	table.cart {
-		img {
-			width: 100%;
-			max-width: 100px;
-			margin-bottom: 0;
-		}
-
-		td.actions .input-text {
-			padding: 7px !important;
-		}
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -228,12 +228,6 @@ function velux_colors( $colors ) {
 		),
 		'button_color' => array(
 			'default' => '#8e452a',
-			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
-				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
-					'background-color' => '%1$s',
-				),
-			),
 		),
 		'button_text_color' => array(
 			'default' => '#ffffff',

--- a/functions.php
+++ b/functions.php
@@ -229,7 +229,8 @@ function velux_colors( $colors ) {
 		'button_color' => array(
 			'default' => '#8e452a',
 			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
+				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
 					'background-color' => '%1$s',
 				),
 			),

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1591,7 +1591,7 @@ body.page-template-page-builder-no-header .content-area {
 
 body.custom-header-image .site-title,
 body.custom-header-image .site-description {
-  text-shadow: -1px -1px 15px rgba(0, 0, 0, 0.5); }
+  text-shadow: -1px 1px 15px rgba(0, 0, 0, 0.5); }
 
 .site-title-wrapper {
   padding: 20px 20px 0 0;
@@ -2474,20 +2474,28 @@ body.no-max-width .site-info-wrapper .site-info {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2485,6 +2485,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: right; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2495,6 +2495,16 @@ body.no-max-width .site-info-wrapper .site-info {
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
 
@@ -2526,18 +2536,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
   text-align: right; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2550,7 +2550,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2474,6 +2474,45 @@ body.no-max-width .site-info-wrapper .site-info {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-right: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.4em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 80px 0 0; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 50%;
+  margin-left: 0; }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px !important; }
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
   max-width: 100%;
@@ -2510,16 +2549,6 @@ body.single-product .quantity .input-text {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -2485,6 +2485,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: left; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style.css
+++ b/style.css
@@ -2495,6 +2495,16 @@ body.no-max-width .site-info-wrapper .site-info {
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
 
@@ -2526,18 +2536,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
   text-align: left; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -2474,6 +2474,45 @@ body.no-max-width .site-info-wrapper .site-info {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-left: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.4em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 0 0 80px; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 50%;
+  margin-right: 0; }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px !important; }
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
   max-width: 100%;
@@ -2510,16 +2549,6 @@ body.single-product .quantity .input-text {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -2474,20 +2474,28 @@ body.no-max-width .site-info-wrapper .site-info {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -2550,7 +2550,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {


### PR DESCRIPTION
@fjarrett Please review.

Prevent button overlaps, adjust font size for WooCommerce compat.

Related https://github.com/godaddy/wp-primer-theme/pull/167

Additional tweaks for WooCommerce styles. For a complete list see https://github.com/godaddy/wp-primer-theme/pull/182

![example](https://cldup.com/O8Y27s-onM.png)