### PR TITLE
Introduce video header styles

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,6 +1,7 @@
 .site-header-wrapper {
 
 	position: relative;
+	z-index: 1;
 
 	@include container($container-size);
 	border-bottom: 1px solid white;

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -22,6 +22,14 @@
 	z-index: 999;
 	background-color: $color__background-header;
 
+
+	#wp-custom-header {
+
+		img {
+			display: none;
+		}
+	}
+
 	.home & {
 		background-size: cover;
 	}

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,3 +1,5 @@
+@import "video-header";
+
 .site-header-wrapper {
 
 	position: relative;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -1,35 +1,3 @@
-.site-header.video-header {
-	background-color: #000;
-	color: #000;
-
-	.hero,
-	aside.primer-hero-text-widget {
-		position: relative;
-		z-index: 5;
-	}
-
-	#wp-custom-header {
-		position: absolute;
-		height: 100%;
-		top: 0;
-		left: 0;
-
-		img {
-			display: none;
-		}
-	}
-
-	#wp-custom-header-video-button {
-		display: none;
-	}
-
-	iframe#wp-custom-header-video {
-		height: 100%;
-		max-width: 100%;
-	}
-
-}
-
 .hero {
 	@include container($container-size);
 

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -1,3 +1,35 @@
+.site-header.video-header {
+	background-color: #000;
+	color: #000;
+
+	.hero,
+	aside.primer-hero-text-widget {
+		position: relative;
+		z-index: 5;
+	}
+
+	#wp-custom-header {
+		position: absolute;
+		height: 100%;
+		top: 0;
+		left: 0;
+
+		img {
+			display: none;
+		}
+	}
+
+	#wp-custom-header-video-button {
+		display: none;
+	}
+
+	iframe#wp-custom-header-video {
+		height: 100%;
+		max-width: 100%;
+	}
+
+}
+
 .hero {
 	@include container($container-size);
 

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -1,0 +1,39 @@
+.site-header.video-header {
+	overflow: hidden;
+	background-color: #000;
+	color: #000;
+
+	.hero,
+	aside.primer-hero-text-widget {
+		position: relative;
+		z-index: 5;
+	}
+
+	#wp-custom-header {
+		position: absolute;
+		height: 100vh;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		margin: auto;
+
+		img {
+			display: none;
+		}
+	}
+
+	#wp-custom-header-video-button {
+		position: absolute;
+		top: 81vh;
+		right: 1em;
+		opacity: 0.5;
+		padding: 10px 1rem;
+	}
+
+	iframe#wp-custom-header-video {
+		height: 100%;
+		max-width: 100%;
+	}
+
+}

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -25,7 +25,7 @@
 
 	#wp-custom-header-video-button {
 		position: absolute;
-		top: 81vh;
+		top: 89vh;
 		right: 1em;
 		opacity: 0.5;
 		padding: 10px 1rem;

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.1.0' );
+define( 'PRIMER_CHILD_VERSION', '1.0.0' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.0.0' );
+define( 'PRIMER_CHILD_VERSION', '1.1.0' );
 
 /**
  * Move some elements around.
@@ -22,10 +22,13 @@ function velux_move_elements() {
 	remove_action( 'primer_after_header',              'primer_add_page_title',         12 );
 	remove_action( 'primer_before_site_navigation',    'primer_add_mobile_menu' );
 	remove_action( 'primer_after_post_title_template', 'primer_add_post_meta' );
+	remove_action( 'primer_before_header_wrapper',     'primer_video_header',           5 );
 
 	add_action( 'primer_header',           'primer_add_primary_navigation' );
 
 	add_action( 'primer_after_post_title', 'primer_add_post_meta' );
+
+	add_action( 'primer_after_site_header_wrapper', 'primer_video_header',           3 );
 
 	if ( is_front_page() && is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -28,7 +28,7 @@ function velux_move_elements() {
 
 	add_action( 'primer_after_post_title', 'primer_add_post_meta' );
 
-	add_action( 'primer_after_site_header_wrapper', 'primer_video_header',           3 );
+	add_action( 'primer_after_site_header_wrapper', 'primer_video_header' );
 
 	if ( is_front_page() && is_active_sidebar( 'hero' ) ) {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1566,6 +1566,8 @@ body.page-template-page-builder-no-header .content-area {
   background-size: cover;
   z-index: 999;
   background-color: #51748e; }
+  .site-header #wp-custom-header img {
+    display: none; }
   .home .site-header {
     -webkit-background-size: cover;
     background-size: cover; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1544,6 +1544,7 @@ body.page-template-page-builder-no-header .content-area {
 --------------------------------------------------------------*/
 .site-header-wrapper {
   position: relative;
+  z-index: 1;
   max-width: 1100px;
   margin-right: auto;
   margin-left: auto;
@@ -1591,7 +1592,7 @@ body.page-template-page-builder-no-header .content-area {
 
 body.custom-header-image .site-title,
 body.custom-header-image .site-description {
-  text-shadow: -1px -1px 15px rgba(0, 0, 0, 0.5); }
+  text-shadow: -1px 1px 15px rgba(0, 0, 0, 0.5); }
 
 .site-title-wrapper {
   padding: 20px 20px 0 0;
@@ -1676,6 +1677,26 @@ body.no-max-width .page-title-container .page-header {
 /*--------------------------------------------------------------
 # Hero
 --------------------------------------------------------------*/
+.site-header.video-header {
+  background-color: #000;
+  color: #000; }
+  .site-header.video-header .hero,
+  .site-header.video-header aside.primer-hero-text-widget {
+    position: relative;
+    z-index: 5; }
+  .site-header.video-header #wp-custom-header {
+    position: absolute;
+    height: 100%;
+    top: 0;
+    right: 0; }
+    .site-header.video-header #wp-custom-header img {
+      display: none; }
+  .site-header.video-header #wp-custom-header-video-button {
+    display: none; }
+  .site-header.video-header iframe#wp-custom-header-video {
+    height: 100%;
+    max-width: 100%; }
+
 .hero {
   max-width: 1100px;
   margin-right: auto;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1542,6 +1542,34 @@ body.page-template-page-builder-no-header .content-area {
 /*--------------------------------------------------------------
 # Header
 --------------------------------------------------------------*/
+.site-header.video-header {
+  overflow: hidden;
+  background-color: #000;
+  color: #000; }
+  .site-header.video-header .hero,
+  .site-header.video-header aside.primer-hero-text-widget {
+    position: relative;
+    z-index: 5; }
+  .site-header.video-header #wp-custom-header {
+    position: absolute;
+    height: 100vh;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    margin: auto; }
+    .site-header.video-header #wp-custom-header img {
+      display: none; }
+  .site-header.video-header #wp-custom-header-video-button {
+    position: absolute;
+    top: 81vh;
+    left: 1em;
+    opacity: 0.5;
+    padding: 10px 1rem; }
+  .site-header.video-header iframe#wp-custom-header-video {
+    height: 100%;
+    max-width: 100%; }
+
 .site-header-wrapper {
   position: relative;
   z-index: 1;
@@ -1679,26 +1707,6 @@ body.no-max-width .page-title-container .page-header {
 /*--------------------------------------------------------------
 # Hero
 --------------------------------------------------------------*/
-.site-header.video-header {
-  background-color: #000;
-  color: #000; }
-  .site-header.video-header .hero,
-  .site-header.video-header aside.primer-hero-text-widget {
-    position: relative;
-    z-index: 5; }
-  .site-header.video-header #wp-custom-header {
-    position: absolute;
-    height: 100%;
-    top: 0;
-    right: 0; }
-    .site-header.video-header #wp-custom-header img {
-      display: none; }
-  .site-header.video-header #wp-custom-header-video-button {
-    display: none; }
-  .site-header.video-header iframe#wp-custom-header-video {
-    height: 100%;
-    max-width: 100%; }
-
 .hero {
   max-width: 1100px;
   margin-right: auto;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1570,7 +1570,7 @@ body.page-template-page-builder-no-header .content-area {
       display: none; }
   .site-header.video-header #wp-custom-header-video-button {
     position: absolute;
-    top: 81vh;
+    top: 89vh;
     left: 1em;
     opacity: 0.5;
     padding: 10px 1rem; }

--- a/style.css
+++ b/style.css
@@ -1542,6 +1542,34 @@ body.page-template-page-builder-no-header .content-area {
 /*--------------------------------------------------------------
 # Header
 --------------------------------------------------------------*/
+.site-header.video-header {
+  overflow: hidden;
+  background-color: #000;
+  color: #000; }
+  .site-header.video-header .hero,
+  .site-header.video-header aside.primer-hero-text-widget {
+    position: relative;
+    z-index: 5; }
+  .site-header.video-header #wp-custom-header {
+    position: absolute;
+    height: 100vh;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto; }
+    .site-header.video-header #wp-custom-header img {
+      display: none; }
+  .site-header.video-header #wp-custom-header-video-button {
+    position: absolute;
+    top: 81vh;
+    right: 1em;
+    opacity: 0.5;
+    padding: 10px 1rem; }
+  .site-header.video-header iframe#wp-custom-header-video {
+    height: 100%;
+    max-width: 100%; }
+
 .site-header-wrapper {
   position: relative;
   z-index: 1;
@@ -1679,26 +1707,6 @@ body.no-max-width .page-title-container .page-header {
 /*--------------------------------------------------------------
 # Hero
 --------------------------------------------------------------*/
-.site-header.video-header {
-  background-color: #000;
-  color: #000; }
-  .site-header.video-header .hero,
-  .site-header.video-header aside.primer-hero-text-widget {
-    position: relative;
-    z-index: 5; }
-  .site-header.video-header #wp-custom-header {
-    position: absolute;
-    height: 100%;
-    top: 0;
-    left: 0; }
-    .site-header.video-header #wp-custom-header img {
-      display: none; }
-  .site-header.video-header #wp-custom-header-video-button {
-    display: none; }
-  .site-header.video-header iframe#wp-custom-header-video {
-    height: 100%;
-    max-width: 100%; }
-
 .hero {
   max-width: 1100px;
   margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -1566,6 +1566,8 @@ body.page-template-page-builder-no-header .content-area {
   background-size: cover;
   z-index: 999;
   background-color: #51748e; }
+  .site-header #wp-custom-header img {
+    display: none; }
   .home .site-header {
     -webkit-background-size: cover;
     background-size: cover; }

--- a/style.css
+++ b/style.css
@@ -1544,6 +1544,7 @@ body.page-template-page-builder-no-header .content-area {
 --------------------------------------------------------------*/
 .site-header-wrapper {
   position: relative;
+  z-index: 1;
   max-width: 1100px;
   margin-left: auto;
   margin-right: auto;
@@ -1676,6 +1677,26 @@ body.no-max-width .page-title-container .page-header {
 /*--------------------------------------------------------------
 # Hero
 --------------------------------------------------------------*/
+.site-header.video-header {
+  background-color: #000;
+  color: #000; }
+  .site-header.video-header .hero,
+  .site-header.video-header aside.primer-hero-text-widget {
+    position: relative;
+    z-index: 5; }
+  .site-header.video-header #wp-custom-header {
+    position: absolute;
+    height: 100%;
+    top: 0;
+    left: 0; }
+    .site-header.video-header #wp-custom-header img {
+      display: none; }
+  .site-header.video-header #wp-custom-header-video-button {
+    display: none; }
+  .site-header.video-header iframe#wp-custom-header-video {
+    height: 100%;
+    max-width: 100%; }
+
 .hero {
   max-width: 1100px;
   margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -1570,7 +1570,7 @@ body.page-template-page-builder-no-header .content-area {
       display: none; }
   .site-header.video-header #wp-custom-header-video-button {
     position: absolute;
-    top: 81vh;
+    top: 89vh;
     right: 1em;
     opacity: 0.5;
     padding: 10px 1rem; }


### PR DESCRIPTION
Since WordPress 4.7, video headers have been possible. This PR introduces styles to accommodate video headers within Velux.

Version was bumped to 1.1.0, since 1.0.0 was not working properly with the new primer priorities.