### PR TITLE
Prevent site title overlapping mobile menu toggle

### DIFF
--- a/.dev/sass/components/_menus.scss
+++ b/.dev/sass/components/_menus.scss
@@ -220,7 +220,7 @@ body.no-max-width .main-navigation {
 	display: inline-block;
 	margin: 0 auto;
 	width: 3.9rem;
-	padding: 0.6rem;
+	padding: 0.15rem 0.6rem 0.6rem 0.6rem;
 	cursor: pointer;
 	position: absolute;
 	z-index: 9999;

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -61,12 +61,13 @@ body.custom-header-image {
 
 .site-title-wrapper {
 	padding: 20px 0 0 20px;
-	width: auto;
+	width: 80%;
 	float: left;
 
 	@media #{$medium-up} {
 		padding-top: 0;
 		text-align: left;
+		width: 100%;
 	}
 
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -765,7 +765,7 @@ body.no-max-width .main-navigation {
   display: inline-block;
   margin: 0 auto;
   width: 3.9rem;
-  padding: 0.6rem;
+  padding: 0.15rem 0.6rem 0.6rem 0.6rem;
   cursor: pointer;
   position: absolute;
   z-index: 9999;
@@ -1666,12 +1666,13 @@ body.custom-header-image .site-description {
 
 .site-title-wrapper {
   padding: 20px 20px 0 0;
-  width: auto;
+  width: 80%;
   float: right; }
   @media only screen and (min-width: 40.063em) {
     .site-title-wrapper {
       padding-top: 0;
-      text-align: right; } }
+      text-align: right;
+      width: 100%; } }
 
 .site-title {
   text-transform: uppercase;

--- a/style.css
+++ b/style.css
@@ -765,7 +765,7 @@ body.no-max-width .main-navigation {
   display: inline-block;
   margin: 0 auto;
   width: 3.9rem;
-  padding: 0.6rem;
+  padding: 0.15rem 0.6rem 0.6rem 0.6rem;
   cursor: pointer;
   position: absolute;
   z-index: 9999;
@@ -1666,12 +1666,13 @@ body.custom-header-image .site-description {
 
 .site-title-wrapper {
   padding: 20px 0 0 20px;
-  width: auto;
+  width: 80%;
   float: left; }
   @media only screen and (min-width: 40.063em) {
     .site-title-wrapper {
       padding-top: 0;
-      text-align: left; } }
+      text-align: left;
+      width: 100%; } }
 
 .site-title {
   text-transform: uppercase;


### PR DESCRIPTION
Resolves #48
Resolves #49 

Adjust site title width & tweak menu-toggle top padding. This helps prevent the title from overlapping the mobile menu hamburger toggle.