### PR TITLE
Introduce Gutenberg block support

### DIFF
--- a/.dev/sass/compat/gutenberg.scss
+++ b/.dev/sass/compat/gutenberg.scss
@@ -1,103 +1,73 @@
 /*--------------------------------------------------------------
 >>> Gutenberg:
 --------------------------------------------------------------*/
-.wp-block-cover-image.alignfull,
-.wp-block-image.alignfull,
-.wp-block-cover-text.alignfull,
-.wp-block-image.alignfull,
-.wp-block-gallery.alignfull,
-.wp-block-text-columns.alignfull {
-	margin-left: -1.4%;
-	width: calc( 102.8% + 15px );
-
-	img {
-		width: 100%;
-	}
-
-	figcaption {
-		padding: 0 3.375em;
-	}
-
-	@media #{$medium-down} {
-		figcaption {
-			padding: 0 2.375em;
-		}
-	}
-
-	@media #{$small-only} {
-		margin-left: calc( -1em - 1.45% );
-		width: calc( 102.9% + 2em );
-
-		figcaption {
-			padding: 0 1em;
-		}
-	}
-}
-
-.wp-block-cover-image.alignwide,
-.wp-block-image.alignwide,
-.wp-block-cover-text.alignwide,
-.wp-block-image.alignwide,
-.wp-block-gallery.alignwide,
-.wp-block-text-columns.alignwide {
-	margin-left: -1.6875em;
-	margin-right: -1.6875em;
-	width: calc( 100% + 3.375em );
-
-	@media #{$small-only} {
-		margin-left: -1.5em;
-		width: calc( 100% + 3em );
-	}
-}
-
-.wp-block-image,
-.wp-block-gallery,
-.wp-block-video,
-.wp-block-quote,
-.wp-block-text-columns,
-.entry-content ul,
-.entry-content ol,
-.wp-block-cover-text {
-	&.alignleft {
-		margin: 0 1.5em 1.5em 0;
-	}
-
-	&.alignright {
-		margin: 0 0 1.5em 1.5em;
-	}
-
-	&.alignleft,
-	&.alignright {
-		max-width: calc( 0.4 * #{$container-size} );
-		@media #{$medium-only} {
-			max-width: calc( 0.25 * #{$container-size} );
-			margin-bottom: 0.5em;
-		}
-		@media #{$small-only} {
-			max-width: 100%;
-			margin-left: 0;
-			margin-right: 0;
-		}
-	}
-}
-
-.wp-block-pullquote {
-	padding: 2em 0;
-
-	p {
-		margin: 0 0 0.25rem 0;
-	}
-}
-
 body.customize-support {
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	.site-title,
-	.page-title {
-		clear: none;
+	.wp-block-cover-image {
+		margin-bottom: 1.5rem;
+	}
+
+	.alignfull {
+		width: 100.5vw;
+		position: relative;
+		left: 50%;
+		right: 50%;
+		margin-left: -50vw;
+		margin-right: -50vw;
+
+		@media #{$small-only} {
+			width: 100vw;
+		}
+
+		img {
+			width: 100%;
+		}
+	}
+
+	.alignwide {
+		margin-left: -1.5%;
+		margin-right: -1.5%;
+		width: 102%;
+
+		@media #{$medium-only} {
+			margin-left: -1.25%;
+			margin-right: -1.25%;
+			width: 102.5%
+		}
+	}
+
+	.wp-block-image,
+	.wp-block-gallery,
+	.wp-block-video,
+	.wp-block-quote,
+	.wp-block-text-columns,
+	.entry-content ul,
+	.entry-content ol,
+	.wp-block-cover-text {
+		&.alignleft {
+			margin: 0 1em 0.5em 0;
+		}
+
+		&.alignright {
+			margin: 0 0 0.5em 1em;
+		}
+
+		&.alignleft,
+		&.alignright {
+			max-width: 40%;
+			width: 100%;
+
+			img {
+				width: inherit;
+			}
+		}
+	}
+
+	.wp-block-gallery {
+		margin-left: 0;
+		margin-right: 0;
+
+		&.is-cropped .blocks-gallery-item img {
+			height: auto;
+		}
 	}
 }

--- a/.dev/sass/compat/gutenberg.scss
+++ b/.dev/sass/compat/gutenberg.scss
@@ -1,0 +1,77 @@
+/*--------------------------------------------------------------
+>>> Gutenberg:
+--------------------------------------------------------------*/
+.wp-block-cover-image.alignfull,
+.wp-block-image.alignfull,
+.wp-block-cover-text.alignfull,
+.wp-block-image.alignfull,
+.wp-block-gallery.alignfull,
+.wp-block-text-columns.alignfull {
+	width: calc( 100% + 15px );
+
+	figcaption {
+		padding: 0 3.375em;
+	}
+
+	@media #{$medium-down} {
+		figcaption {
+			padding: 0 2.375em;
+		}
+	}
+
+	@media #{$small-only} {
+		width: 100%;
+
+		figcaption {
+			padding: 0 1em;
+		}
+	}
+}
+
+.wp-block-cover-image.alignwide,
+.wp-block-image.alignwide,
+.wp-block-cover-text.alignwide,
+.wp-block-image.alignwide,
+.wp-block-gallery.alignwide,
+.wp-block-text-columns.alignwide {
+	margin-left: -1.6875em;
+	margin-right: -1.6875em;
+	width: calc( 100% + 3.375em );
+
+	@media #{$small-only} {
+		margin-left: -1.5em;
+		width: calc( 100% + 3em );
+	}
+}
+
+.wp-block-image,
+.wp-block-gallery,
+.wp-block-video,
+.wp-block-quote,
+.wp-block-text-columns,
+.entry-content ul,
+.entry-content ol,
+.wp-block-cover-text {
+	&.alignleft {
+		max-width: calc( 0.4 * #{$container-size} );
+		margin: 0 1.5em 1.5em 0;
+	}
+
+	&.alignright {
+		max-width: calc( 0.4 * #{$container-size} );
+		margin: 0 0 1.5em 1.5em;
+	}
+}
+
+body.customize-support {
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	.site-title,
+	.page-title {
+		clear: none;
+	}
+}

--- a/.dev/sass/compat/gutenberg.scss
+++ b/.dev/sass/compat/gutenberg.scss
@@ -7,7 +7,12 @@
 .wp-block-image.alignfull,
 .wp-block-gallery.alignfull,
 .wp-block-text-columns.alignfull {
-	width: calc( 100% + 15px );
+	margin-left: -1.4%;
+	width: calc( 102.8% + 15px );
+
+	img {
+		width: 100%;
+	}
 
 	figcaption {
 		padding: 0 3.375em;
@@ -20,7 +25,8 @@
 	}
 
 	@media #{$small-only} {
-		width: 100%;
+		margin-left: calc( -1em - 1.45% );
+		width: calc( 102.9% + 2em );
 
 		figcaption {
 			padding: 0 1em;
@@ -53,13 +59,33 @@
 .entry-content ol,
 .wp-block-cover-text {
 	&.alignleft {
-		max-width: calc( 0.4 * #{$container-size} );
 		margin: 0 1.5em 1.5em 0;
 	}
 
 	&.alignright {
-		max-width: calc( 0.4 * #{$container-size} );
 		margin: 0 0 1.5em 1.5em;
+	}
+
+	&.alignleft,
+	&.alignright {
+		max-width: calc( 0.4 * #{$container-size} );
+		@media #{$medium-only} {
+			max-width: calc( 0.25 * #{$container-size} );
+			margin-bottom: 0.5em;
+		}
+		@media #{$small-only} {
+			max-width: 100%;
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+}
+
+.wp-block-pullquote {
+	padding: 2em 0;
+
+	p {
+		margin: 0 0 0.25rem 0;
 	}
 }
 

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -171,3 +171,4 @@
 # Compat
 --------------------------------------------------------------*/
 @import "compat/woocommerce";
+@import "compat/gutenberg.scss";

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -171,4 +171,4 @@
 # Compat
 --------------------------------------------------------------*/
 @import "compat/woocommerce";
-@import "compat/gutenberg.scss";
+@import "compat/gutenberg";

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       },
       "dependencies": {
         "co": {
@@ -64,7 +64,7 @@
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0"
+        "file-type": "^3.1.0"
       },
       "dependencies": {
         "file-type": {
@@ -81,8 +81,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -91,7 +91,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -100,7 +100,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -133,7 +133,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -214,13 +214,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.5",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.2.0",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -238,7 +238,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "beeper": {
@@ -254,13 +254,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "archive-type": "3.2.0",
-        "decompress": "3.0.0",
-        "download": "4.4.3",
-        "exec-series": "1.0.3",
-        "rimraf": "2.2.8",
-        "tempfile": "1.1.1",
-        "url-regex": "3.2.0"
+        "archive-type": "^3.0.1",
+        "decompress": "^3.0.0",
+        "download": "^4.1.2",
+        "exec-series": "^1.0.0",
+        "rimraf": "^2.2.6",
+        "tempfile": "^1.0.0",
+        "url-regex": "^3.0.0"
       },
       "dependencies": {
         "tempfile": {
@@ -270,8 +270,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "uuid": "2.0.3"
+            "os-tmpdir": "^1.0.0",
+            "uuid": "^2.0.1"
           }
         },
         "uuid": {
@@ -290,7 +290,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "executable": "1.1.0"
+        "executable": "^1.0.0"
       }
     },
     "bin-version": {
@@ -300,7 +300,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "find-versions": "1.2.1"
+        "find-versions": "^1.0.0"
       }
     },
     "bin-version-check": {
@@ -310,10 +310,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-version": "1.0.4",
-        "minimist": "1.2.0",
-        "semver": "4.3.6",
-        "semver-truncate": "1.1.2"
+        "bin-version": "^1.0.0",
+        "minimist": "^1.1.0",
+        "semver": "^4.0.3",
+        "semver-truncate": "^1.0.0"
       },
       "dependencies": {
         "semver": {
@@ -332,12 +332,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-check": "2.0.0",
-        "bin-version-check": "2.1.0",
-        "download": "4.4.3",
-        "each-async": "1.1.1",
-        "lazy-req": "1.1.0",
-        "os-filter-obj": "1.0.3"
+        "bin-check": "^2.0.0",
+        "bin-version-check": "^2.1.0",
+        "download": "^4.0.0",
+        "each-async": "^1.1.1",
+        "lazy-req": "^1.0.0",
+        "os-filter-obj": "^1.0.0"
       }
     },
     "bl": {
@@ -346,7 +346,7 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "block-stream": {
@@ -355,7 +355,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "boom": {
@@ -364,7 +364,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -373,7 +373,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -383,9 +383,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "buffer-crc32": {
@@ -400,10 +400,10 @@
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0",
-        "readable-stream": "2.3.3",
-        "uuid": "2.0.3",
-        "vinyl": "1.2.0"
+        "file-type": "^3.1.0",
+        "readable-stream": "^2.0.2",
+        "uuid": "^2.0.1",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "file-type": {
@@ -432,15 +432,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -463,8 +463,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "capture-stack-trace": {
@@ -485,10 +485,10 @@
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "dev": true,
       "requires": {
-        "get-proxy": "1.1.0",
-        "is-obj": "1.0.1",
-        "object-assign": "3.0.0",
-        "tunnel-agent": "0.4.3"
+        "get-proxy": "^1.0.1",
+        "is-obj": "^1.0.0",
+        "object-assign": "^3.0.0",
+        "tunnel-agent": "^0.4.0"
       },
       "dependencies": {
         "object-assign": {
@@ -505,11 +505,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "clap": {
@@ -519,7 +519,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       }
     },
     "class-utils": {
@@ -528,11 +528,11 @@
       "integrity": "sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -541,7 +541,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -550,9 +550,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "isobject": {
@@ -576,7 +576,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
+        "glob": "^7.1.1"
       },
       "dependencies": {
         "glob": {
@@ -585,12 +585,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -601,7 +601,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -616,9 +616,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -646,7 +646,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -667,8 +667,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "colors": {
@@ -683,7 +683,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -692,7 +692,7 @@
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "component-emitter": {
@@ -713,9 +713,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-browserify": {
@@ -724,7 +724,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -764,7 +764,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -773,8 +773,8 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -783,7 +783,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "cssjanus": {
@@ -799,8 +799,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "clap": "1.2.3",
-        "source-map": "0.5.7"
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
       }
     },
     "currently-unhandled": {
@@ -809,7 +809,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dashdash": {
@@ -818,7 +818,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -841,8 +841,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
@@ -872,15 +872,15 @@
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "dev": true,
       "requires": {
-        "buffer-to-vinyl": "1.1.0",
-        "concat-stream": "1.6.0",
-        "decompress-tar": "3.1.0",
-        "decompress-tarbz2": "3.1.0",
-        "decompress-targz": "3.1.0",
-        "decompress-unzip": "3.4.0",
-        "stream-combiner2": "1.1.1",
-        "vinyl-assign": "1.2.1",
-        "vinyl-fs": "2.4.4"
+        "buffer-to-vinyl": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "decompress-tar": "^3.0.0",
+        "decompress-tarbz2": "^3.0.0",
+        "decompress-targz": "^3.0.0",
+        "decompress-unzip": "^3.0.0",
+        "stream-combiner2": "^1.1.1",
+        "vinyl-assign": "^1.0.1",
+        "vinyl-fs": "^2.2.0"
       }
     },
     "decompress-tar": {
@@ -889,12 +889,12 @@
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "dev": true,
       "requires": {
-        "is-tar": "1.0.0",
-        "object-assign": "2.1.1",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.5",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "is-tar": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
       },
       "dependencies": {
         "clone": {
@@ -915,8 +915,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -927,13 +927,13 @@
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "dev": true,
       "requires": {
-        "is-bzip2": "1.0.0",
-        "object-assign": "2.1.1",
-        "seek-bzip": "1.0.5",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.5",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "is-bzip2": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "seek-bzip": "^1.0.3",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
       },
       "dependencies": {
         "clone": {
@@ -954,8 +954,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -966,12 +966,12 @@
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "dev": true,
       "requires": {
-        "is-gzip": "1.0.0",
-        "object-assign": "2.1.1",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.5",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "is-gzip": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
       },
       "dependencies": {
         "clone": {
@@ -992,8 +992,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -1004,13 +1004,13 @@
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "dev": true,
       "requires": {
-        "is-zip": "1.0.0",
-        "read-all-stream": "3.1.0",
-        "stat-mode": "0.2.2",
-        "strip-dirs": "1.1.1",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "yauzl": "2.9.1"
+        "is-zip": "^1.0.0",
+        "read-all-stream": "^3.0.0",
+        "stat-mode": "^0.2.0",
+        "strip-dirs": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0",
+        "yauzl": "^2.2.1"
       },
       "dependencies": {
         "through2": {
@@ -1019,8 +1019,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1037,7 +1037,7 @@
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.1"
+        "is-descriptor": "^1.0.0"
       }
     },
     "delayed-stream": {
@@ -1058,7 +1058,7 @@
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "0.1.0"
+        "fs-exists-sync": "^0.1.0"
       }
     },
     "dom-serializer": {
@@ -1067,8 +1067,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1097,7 +1097,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -1106,8 +1106,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "download": {
@@ -1116,21 +1116,21 @@
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "dev": true,
       "requires": {
-        "caw": "1.2.0",
-        "concat-stream": "1.6.0",
-        "each-async": "1.1.1",
-        "filenamify": "1.2.1",
-        "got": "5.7.1",
-        "gulp-decompress": "1.2.0",
-        "gulp-rename": "1.2.2",
-        "is-url": "1.2.2",
-        "object-assign": "4.1.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "stream-combiner2": "1.1.1",
-        "vinyl": "1.2.0",
-        "vinyl-fs": "2.4.4",
-        "ware": "1.3.0"
+        "caw": "^1.0.1",
+        "concat-stream": "^1.4.7",
+        "each-async": "^1.0.0",
+        "filenamify": "^1.0.1",
+        "got": "^5.0.0",
+        "gulp-decompress": "^1.2.0",
+        "gulp-rename": "^1.2.0",
+        "is-url": "^1.2.0",
+        "object-assign": "^4.0.1",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.2",
+        "stream-combiner2": "^1.1.1",
+        "vinyl": "^1.0.0",
+        "vinyl-fs": "^2.2.0",
+        "ware": "^1.2.0"
       }
     },
     "duplexer2": {
@@ -1139,7 +1139,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.2"
       }
     },
     "duplexify": {
@@ -1148,10 +1148,10 @@
       "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "each-async": {
@@ -1160,8 +1160,8 @@
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -1171,7 +1171,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "end-of-stream": {
@@ -1180,7 +1180,7 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "entities": {
@@ -1195,7 +1195,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -1223,11 +1223,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "0.7.0",
-        "p-finally": "1.0.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2",
-        "tempfile": "2.0.0"
+        "execa": "^0.7.0",
+        "p-finally": "^1.0.0",
+        "pify": "^3.0.0",
+        "rimraf": "^2.5.4",
+        "tempfile": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -1244,7 +1244,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.0.6"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -1256,8 +1256,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async-each-series": "1.1.0",
-        "object-assign": "4.1.1"
+        "async-each-series": "^1.1.0",
+        "object-assign": "^4.1.0"
       }
     },
     "execa": {
@@ -1267,13 +1267,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -1283,9 +1283,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.2.14"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         }
       }
@@ -1297,7 +1297,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "meow": "3.7.0"
+        "meow": "^3.1.0"
       }
     },
     "exit": {
@@ -1318,7 +1318,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1327,7 +1327,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
@@ -1336,7 +1336,7 @@
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.1"
       }
     },
     "extend": {
@@ -1351,7 +1351,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "extglob": {
@@ -1360,7 +1360,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -1383,8 +1383,8 @@
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "time-stamp": "1.1.0"
+        "chalk": "^1.1.1",
+        "time-stamp": "^1.0.0"
       }
     },
     "fd-slicer": {
@@ -1393,7 +1393,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -1402,8 +1402,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-sync-cmp": {
@@ -1436,9 +1436,9 @@
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "1.0.0",
-        "strip-outer": "1.0.0",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "fill-range": {
@@ -1447,11 +1447,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-up": {
@@ -1460,8 +1460,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "find-versions": {
@@ -1471,10 +1471,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0",
-        "semver-regex": "1.0.0"
+        "array-uniq": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "meow": "^3.5.0",
+        "semver-regex": "^1.0.0"
       }
     },
     "findup-sync": {
@@ -1483,7 +1483,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       },
       "dependencies": {
         "glob": {
@@ -1492,11 +1492,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -1519,7 +1519,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -1534,9 +1534,9 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -1545,7 +1545,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fs-exists-sync": {
@@ -1566,10 +1566,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "gauge": {
@@ -1578,14 +1578,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -1594,7 +1594,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -1609,7 +1609,7 @@
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2"
+        "rc": "^1.1.2"
       }
     },
     "get-stdin": {
@@ -1643,7 +1643,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1661,9 +1661,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "glob": {
@@ -1672,12 +1672,12 @@
       "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -1686,8 +1686,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -1696,7 +1696,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -1711,7 +1711,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -1722,8 +1722,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       }
     },
     "glob-stream": {
@@ -1732,14 +1732,14 @@
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "glob": "5.0.15",
-        "glob-parent": "3.1.0",
-        "micromatch": "2.3.11",
-        "ordered-read-streams": "0.3.0",
-        "through2": "0.6.5",
-        "to-absolute-glob": "0.1.1",
-        "unique-stream": "2.2.1"
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
       },
       "dependencies": {
         "glob": {
@@ -1748,11 +1748,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -1763,8 +1763,8 @@
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true,
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       }
     },
     "global-prefix": {
@@ -1773,10 +1773,10 @@
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.2.14"
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       }
     },
     "globby": {
@@ -1785,11 +1785,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.0.6",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "globule": {
@@ -1798,9 +1798,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       },
       "dependencies": {
         "glob": {
@@ -1809,12 +1809,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lodash": {
@@ -1831,7 +1831,7 @@
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
       }
     },
     "got": {
@@ -1840,21 +1840,21 @@
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^3.0.0",
+        "unzip-response": "^1.0.2",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -1875,22 +1875,22 @@
       "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "1.0.0",
-        "grunt-legacy-util": "1.0.0",
-        "iconv-lite": "0.4.18",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "coffee-script": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~1.0.0",
+        "grunt-legacy-util": "~1.0.0",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.0",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.2.8"
       },
       "dependencies": {
         "grunt-cli": {
@@ -1899,10 +1899,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.0",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
           }
         }
       }
@@ -1913,10 +1913,10 @@
       "integrity": "sha1-/kLiR7z6ucKSoSwGLa1PNb3pAsU=",
       "dev": true,
       "requires": {
-        "autoprefixer-core": "5.2.1",
-        "chalk": "1.0.0",
-        "diff": "1.3.2",
-        "postcss": "4.1.16"
+        "autoprefixer-core": "^5.1.7",
+        "chalk": "~1.0.0",
+        "diff": "~1.3.0",
+        "postcss": "^4.1.11"
       },
       "dependencies": {
         "autoprefixer-core": {
@@ -1925,10 +1925,10 @@
           "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
           "dev": true,
           "requires": {
-            "browserslist": "0.4.0",
-            "caniuse-db": "1.0.30000529",
-            "num2fraction": "1.2.2",
-            "postcss": "4.1.16"
+            "browserslist": "~0.4.0",
+            "caniuse-db": "^1.0.30000214",
+            "num2fraction": "^1.1.0",
+            "postcss": "~4.1.12"
           },
           "dependencies": {
             "browserslist": {
@@ -1937,7 +1937,7 @@
               "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
               "dev": true,
               "requires": {
-                "caniuse-db": "1.0.30000529"
+                "caniuse-db": "^1.0.30000153"
               }
             },
             "caniuse-db": {
@@ -1960,11 +1960,11 @@
           "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "1.0.3",
-            "strip-ansi": "2.0.1",
-            "supports-color": "1.3.1"
+            "ansi-styles": "^2.0.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^1.0.3",
+            "strip-ansi": "^2.0.1",
+            "supports-color": "^1.3.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -1985,8 +1985,8 @@
               "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
               "dev": true,
               "requires": {
-                "ansi-regex": "1.1.1",
-                "get-stdin": "4.0.1"
+                "ansi-regex": "^1.1.0",
+                "get-stdin": "^4.0.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -2009,7 +2009,7 @@
               "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
               "dev": true,
               "requires": {
-                "ansi-regex": "1.1.1"
+                "ansi-regex": "^1.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -2040,9 +2040,9 @@
           "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
           "dev": true,
           "requires": {
-            "es6-promise": "2.3.0",
-            "js-base64": "2.1.9",
-            "source-map": "0.4.4"
+            "es6-promise": "~2.3.0",
+            "js-base64": "~2.1.8",
+            "source-map": "~0.4.2"
           },
           "dependencies": {
             "es6-promise": {
@@ -2063,7 +2063,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.0"
+                "amdefine": ">=0.0.4"
               },
               "dependencies": {
                 "amdefine": {
@@ -2084,8 +2084,8 @@
       "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "rimraf": "2.6.1"
+        "async": "^1.5.2",
+        "rimraf": "^2.5.1"
       },
       "dependencies": {
         "rimraf": {
@@ -2094,7 +2094,7 @@
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
-            "glob": "7.0.6"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -2105,8 +2105,8 @@
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "file-sync-cmp": "0.1.1"
+        "chalk": "^1.1.1",
+        "file-sync-cmp": "^0.1.0"
       }
     },
     "grunt-contrib-imagemin": {
@@ -2115,15 +2115,15 @@
       "integrity": "sha512-91zBrvh350QSpsxyCTXni0djMXavF3elBmvFgnbp/2CgIx53QYe+Cvf2+wZmrcb8U0qp+MjHl0Ahjct4+R6PLQ==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "imagemin": "5.3.1",
-        "imagemin-gifsicle": "5.2.0",
-        "imagemin-jpegtran": "5.0.2",
-        "imagemin-optipng": "5.2.1",
-        "imagemin-svgo": "5.2.4",
-        "p-map": "1.2.0",
-        "plur": "2.1.2",
-        "pretty-bytes": "4.0.2"
+        "chalk": "^1.0.0",
+        "imagemin": "^5.3.1",
+        "imagemin-gifsicle": "^5.0.0",
+        "imagemin-jpegtran": "^5.0.0",
+        "imagemin-optipng": "^5.1.0",
+        "imagemin-svgo": "^5.1.0",
+        "p-map": "^1.1.1",
+        "plur": "^2.1.2",
+        "pretty-bytes": "^4.0.2"
       }
     },
     "grunt-contrib-jshint": {
@@ -2132,9 +2132,9 @@
       "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "hooker": "0.2.3",
-        "jshint": "2.9.5"
+        "chalk": "^1.1.1",
+        "hooker": "^0.2.3",
+        "jshint": "~2.9.4"
       }
     },
     "grunt-contrib-watch": {
@@ -2143,10 +2143,10 @@
       "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "gaze": "1.1.1",
-        "lodash": "3.10.1",
-        "tiny-lr": "0.2.1"
+        "async": "^1.5.0",
+        "gaze": "^1.0.0",
+        "lodash": "^3.10.1",
+        "tiny-lr": "^0.2.1"
       },
       "dependencies": {
         "async": {
@@ -2161,7 +2161,7 @@
           "integrity": "sha1-q4HVV9G1FfV1K9XxEX1vo8Tp20E=",
           "dev": true,
           "requires": {
-            "globule": "1.0.0"
+            "globule": "^1.0.0"
           },
           "dependencies": {
             "globule": {
@@ -2170,9 +2170,9 @@
               "integrity": "sha1-8irrqszgK+SSRT6XnDrptpg/HGw=",
               "dev": true,
               "requires": {
-                "glob": "7.0.6",
-                "lodash": "4.9.0",
-                "minimatch": "3.0.3"
+                "glob": "~7.0.3",
+                "lodash": "~4.9.0",
+                "minimatch": "~3.0.0"
               },
               "dependencies": {
                 "glob": {
@@ -2181,12 +2181,12 @@
                   "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.5",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.0"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -2201,8 +2201,8 @@
                       "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -2225,7 +2225,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -2256,7 +2256,7 @@
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -2265,7 +2265,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -2301,12 +2301,12 @@
           "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
           "dev": true,
           "requires": {
-            "body-parser": "1.14.2",
-            "debug": "2.2.0",
-            "faye-websocket": "0.10.0",
-            "livereload-js": "2.2.2",
-            "parseurl": "1.3.1",
-            "qs": "5.1.0"
+            "body-parser": "~1.14.0",
+            "debug": "~2.2.0",
+            "faye-websocket": "~0.10.0",
+            "livereload-js": "^2.2.0",
+            "parseurl": "~1.3.0",
+            "qs": "~5.1.0"
           },
           "dependencies": {
             "body-parser": {
@@ -2316,15 +2316,15 @@
               "dev": true,
               "requires": {
                 "bytes": "2.2.0",
-                "content-type": "1.0.2",
-                "debug": "2.2.0",
-                "depd": "1.1.0",
-                "http-errors": "1.3.1",
+                "content-type": "~1.0.1",
+                "debug": "~2.2.0",
+                "depd": "~1.1.0",
+                "http-errors": "~1.3.1",
                 "iconv-lite": "0.4.13",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "5.2.0",
-                "raw-body": "2.1.7",
-                "type-is": "1.6.13"
+                "raw-body": "~2.1.5",
+                "type-is": "~1.6.10"
               },
               "dependencies": {
                 "bytes": {
@@ -2351,8 +2351,8 @@
                   "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "statuses": "1.3.0"
+                    "inherits": "~2.0.1",
+                    "statuses": "1"
                   },
                   "dependencies": {
                     "inherits": {
@@ -2430,7 +2430,7 @@
                   "dev": true,
                   "requires": {
                     "media-typer": "0.3.0",
-                    "mime-types": "2.1.11"
+                    "mime-types": "~2.1.11"
                   },
                   "dependencies": {
                     "media-typer": {
@@ -2445,7 +2445,7 @@
                       "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
                       "dev": true,
                       "requires": {
-                        "mime-db": "1.23.0"
+                        "mime-db": "~1.23.0"
                       },
                       "dependencies": {
                         "mime-db": {
@@ -2483,7 +2483,7 @@
               "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
               "dev": true,
               "requires": {
-                "websocket-driver": "0.6.5"
+                "websocket-driver": ">=0.5.1"
               },
               "dependencies": {
                 "websocket-driver": {
@@ -2492,7 +2492,7 @@
                   "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
                   "dev": true,
                   "requires": {
-                    "websocket-extensions": "0.1.1"
+                    "websocket-extensions": ">=0.1.1"
                   },
                   "dependencies": {
                     "websocket-extensions": {
@@ -2533,7 +2533,7 @@
       "integrity": "sha1-j8rmiZDMU+wpReVi3j3Jn17MMXs=",
       "dev": true,
       "requires": {
-        "cssjanus": "1.2.0"
+        "cssjanus": "^1.1.2"
       }
     },
     "grunt-dev-update": {
@@ -2542,12 +2542,12 @@
       "integrity": "sha512-q/DUppB7YuRUJM0tthz4EzyfYfaiEmfTIZGaFTx6dyrkOZO+McrMgQVoO0A5+lFwPxPFKhPEXwhxWitADNcn6w==",
       "dev": true,
       "requires": {
-        "async-each-series": "1.1.0",
-        "findup-sync": "0.4.3",
-        "inquirer": "0.12.0",
-        "lodash": "4.17.4",
-        "npm-package-arg": "4.2.1",
-        "semver": "5.4.1"
+        "async-each-series": "^1.1.0",
+        "findup-sync": "^0.4.0",
+        "inquirer": "^0.12.0",
+        "lodash": "^4.8.2",
+        "npm-package-arg": "^4.1.0",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "findup-sync": {
@@ -2556,10 +2556,10 @@
           "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
           "dev": true,
           "requires": {
-            "detect-file": "0.1.0",
-            "is-glob": "2.0.1",
-            "micromatch": "2.3.11",
-            "resolve-dir": "0.1.1"
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
           }
         },
         "is-extglob": {
@@ -2574,7 +2574,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "lodash": {
@@ -2597,11 +2597,11 @@
       "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "1.0.0",
-        "hooker": "0.2.3",
-        "lodash": "3.10.1",
-        "underscore.string": "3.2.3"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~1.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~3.10.1",
+        "underscore.string": "~3.2.3"
       }
     },
     "grunt-legacy-log-utils": {
@@ -2610,8 +2610,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "4.3.0"
+        "chalk": "~1.1.1",
+        "lodash": "~4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -2628,13 +2628,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.3.0",
-        "underscore.string": "3.2.3",
-        "which": "1.2.14"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.3.0",
+        "underscore.string": "~3.2.3",
+        "which": "~1.2.1"
       },
       "dependencies": {
         "lodash": {
@@ -2651,9 +2651,9 @@
       "integrity": "sha1-kHTPnXtFkuIPd4jKpye4+aoGtgo=",
       "dev": true,
       "requires": {
-        "each-async": "1.1.1",
-        "node-sass": "4.5.3",
-        "object-assign": "4.1.1"
+        "each-async": "^1.0.0",
+        "node-sass": "^4.0.0",
+        "object-assign": "^4.0.1"
       }
     },
     "grunt-text-replace": {
@@ -2674,10 +2674,10 @@
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "dev": true,
       "requires": {
-        "archive-type": "3.2.0",
-        "decompress": "3.0.0",
-        "gulp-util": "3.0.8",
-        "readable-stream": "2.3.3"
+        "archive-type": "^3.0.0",
+        "decompress": "^3.0.0",
+        "gulp-util": "^3.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "gulp-rename": {
@@ -2692,11 +2692,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.0",
-        "graceful-fs": "4.1.11",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "through2": {
@@ -2705,8 +2705,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -2717,24 +2717,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.2.0",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^2.0.0",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
       },
       "dependencies": {
         "dateformat": {
@@ -2761,8 +2761,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "vinyl": {
@@ -2771,8 +2771,8 @@
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "dev": true,
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -2784,7 +2784,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "^1.0.0"
       }
     },
     "har-schema": {
@@ -2799,8 +2799,8 @@
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has-ansi": {
@@ -2809,7 +2809,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-gulplog": {
@@ -2818,7 +2818,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
       }
     },
     "has-unicode": {
@@ -2833,9 +2833,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -2852,8 +2852,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2862,7 +2862,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2871,7 +2871,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2882,7 +2882,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2893,10 +2893,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
@@ -2911,7 +2911,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hooker": {
@@ -2939,11 +2939,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "isarray": {
@@ -2958,10 +2958,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2978,9 +2978,9 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -2995,12 +2995,12 @@
       "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
       "dev": true,
       "requires": {
-        "file-type": "4.4.0",
-        "globby": "6.1.0",
-        "make-dir": "1.1.0",
-        "p-pipe": "1.2.0",
-        "pify": "2.3.0",
-        "replace-ext": "1.0.0"
+        "file-type": "^4.1.0",
+        "globby": "^6.1.0",
+        "make-dir": "^1.0.0",
+        "p-pipe": "^1.1.0",
+        "pify": "^2.3.0",
+        "replace-ext": "^1.0.0"
       }
     },
     "imagemin-gifsicle": {
@@ -3010,9 +3010,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "gifsicle": "3.0.4",
-        "is-gif": "1.0.0"
+        "exec-buffer": "^3.0.0",
+        "gifsicle": "^3.0.0",
+        "is-gif": "^1.0.0"
       }
     },
     "imagemin-jpegtran": {
@@ -3022,9 +3022,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "is-jpg": "1.0.0",
-        "jpegtran-bin": "3.2.0"
+        "exec-buffer": "^3.0.0",
+        "is-jpg": "^1.0.0",
+        "jpegtran-bin": "^3.0.0"
       }
     },
     "imagemin-optipng": {
@@ -3034,9 +3034,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "is-png": "1.1.0",
-        "optipng-bin": "3.1.4"
+        "exec-buffer": "^3.0.0",
+        "is-png": "^1.0.0",
+        "optipng-bin": "^3.0.0"
       }
     },
     "imagemin-svgo": {
@@ -3046,8 +3046,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-svg": "2.1.0",
-        "svgo": "0.7.2"
+        "is-svg": "^2.0.0",
+        "svgo": "^0.7.0"
       }
     },
     "in-publish": {
@@ -3062,7 +3062,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -3071,8 +3071,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3093,19 +3093,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "lodash": {
@@ -3141,7 +3141,7 @@
       "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
       "dev": true,
       "requires": {
-        "is-relative": "0.1.3"
+        "is-relative": "^0.1.0"
       }
     },
     "is-accessor-descriptor": {
@@ -3150,7 +3150,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -3171,7 +3171,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-bzip2": {
@@ -3186,7 +3186,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-descriptor": {
@@ -3195,9 +3195,9 @@
       "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3220,7 +3220,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -3241,7 +3241,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -3250,7 +3250,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-gif": {
@@ -3266,7 +3266,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-gzip": {
@@ -3294,7 +3294,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -3309,7 +3309,7 @@
       "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "^3.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -3318,7 +3318,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -3329,7 +3329,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -3390,7 +3390,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "html-comment-regex": "1.1.1"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-tar": {
@@ -3469,9 +3469,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "js-base64": {
@@ -3486,8 +3486,8 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
       }
     },
     "jsbn": {
@@ -3503,14 +3503,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
       },
       "dependencies": {
         "lodash": {
@@ -3539,7 +3539,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -3580,7 +3580,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -3589,7 +3589,7 @@
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "lazy-req": {
@@ -3605,7 +3605,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -3614,7 +3614,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "load-grunt-tasks": {
@@ -3623,10 +3623,10 @@
       "integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "multimatch": "2.1.0",
-        "pkg-up": "1.0.0",
-        "resolve-pkg": "0.1.0"
+        "arrify": "^1.0.0",
+        "multimatch": "^2.0.0",
+        "pkg-up": "^1.0.0",
+        "resolve-pkg": "^0.1.0"
       },
       "dependencies": {
         "arrify": {
@@ -3641,10 +3641,10 @@
           "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
           "dev": true,
           "requires": {
-            "array-differ": "1.0.0",
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "minimatch": "3.0.3"
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
           },
           "dependencies": {
             "array-differ": {
@@ -3659,7 +3659,7 @@
               "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
               "dev": true,
               "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
               },
               "dependencies": {
                 "array-uniq": {
@@ -3676,7 +3676,7 @@
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -3685,7 +3685,7 @@
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3713,7 +3713,7 @@
           "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -3722,8 +3722,8 @@
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               },
               "dependencies": {
                 "path-exists": {
@@ -3732,7 +3732,7 @@
                   "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                   "dev": true,
                   "requires": {
-                    "pinkie-promise": "2.0.1"
+                    "pinkie-promise": "^2.0.0"
                   }
                 },
                 "pinkie-promise": {
@@ -3741,7 +3741,7 @@
                   "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                   "dev": true,
                   "requires": {
-                    "pinkie": "2.0.4"
+                    "pinkie": "^2.0.0"
                   },
                   "dependencies": {
                     "pinkie": {
@@ -3762,7 +3762,7 @@
           "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
           "dev": true,
           "requires": {
-            "resolve-from": "2.0.0"
+            "resolve-from": "^2.0.0"
           },
           "dependencies": {
             "resolve-from": {
@@ -3781,11 +3781,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -3866,7 +3866,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -3893,9 +3893,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.mergewith": {
@@ -3916,15 +3916,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -3933,8 +3933,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
       }
     },
     "logalot": {
@@ -3944,8 +3944,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "figures": "1.7.0",
-        "squeak": "1.3.0"
+        "figures": "^1.3.5",
+        "squeak": "^1.0.0"
       }
     },
     "longest": {
@@ -3961,8 +3961,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -3978,10 +3978,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "indent-string": "2.1.0",
-        "longest": "1.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "indent-string": "^2.1.0",
+        "longest": "^1.0.0",
+        "meow": "^3.3.0"
       }
     },
     "lru-cache": {
@@ -3990,8 +3990,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -4000,7 +4000,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4029,7 +4029,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "matchdep": {
@@ -4038,9 +4038,9 @@
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
       "dev": true,
       "requires": {
-        "findup-sync": "2.0.0",
-        "micromatch": "3.1.4",
-        "resolve": "1.5.0",
+        "findup-sync": "^2.0.0",
+        "micromatch": "^3.0.4",
+        "resolve": "^1.4.0",
         "stack-trace": "0.0.10"
       },
       "dependencies": {
@@ -4062,17 +4062,17 @@
           "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.0.2",
-            "to-regex": "3.0.1"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           }
         },
         "detect-file": {
@@ -4087,13 +4087,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -4102,7 +4102,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -4113,7 +4113,7 @@
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "1.0.1"
+            "homedir-polyfill": "^1.0.1"
           }
         },
         "extglob": {
@@ -4122,14 +4122,14 @@
           "integrity": "sha512-I0+eZBH+jFGL8F5BnIz2ON2nKCjTS3AS3H/5PeSmCp7UVC70Ym8IhdRiQly2juKYQ//f7z1aj1BRpQniFJoU1w==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "fill-range": {
@@ -4138,10 +4138,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           }
         },
         "findup-sync": {
@@ -4150,10 +4150,10 @@
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
           "dev": true,
           "requires": {
-            "detect-file": "1.0.0",
-            "is-glob": "3.1.0",
-            "micromatch": "3.1.4",
-            "resolve-dir": "1.0.1"
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
           }
         },
         "global-modules": {
@@ -4162,9 +4162,9 @@
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.1",
-            "resolve-dir": "1.0.1"
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
           }
         },
         "global-prefix": {
@@ -4173,11 +4173,11 @@
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
           "dev": true,
           "requires": {
-            "expand-tilde": "2.0.2",
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.4",
-            "is-windows": "1.0.1",
-            "which": "1.2.14"
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
           }
         },
         "is-descriptor": {
@@ -4186,9 +4186,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -4205,7 +4205,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4214,7 +4214,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4243,19 +4243,19 @@
           "integrity": "sha512-kFRtviKYoAJT+t7HggMl0tBFGNAKLw/S7N+CO9qfEQyisob1Oy4pao+geRbkyeEd+V9aOkvZ4mhuyPvI/q9Sfg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.0",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "extglob": "2.0.2",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.0",
-            "nanomatch": "1.2.5",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.0",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "extglob": "^2.0.2",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.0",
+            "nanomatch": "^1.2.5",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "resolve": {
@@ -4264,7 +4264,7 @@
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "resolve-dir": {
@@ -4273,8 +4273,8 @@
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
           "dev": true,
           "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         }
       }
@@ -4285,16 +4285,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "merge-stream": {
@@ -4303,7 +4303,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "micromatch": {
@@ -4312,19 +4312,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       },
       "dependencies": {
         "is-extglob": {
@@ -4339,7 +4339,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -4356,7 +4356,7 @@
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "~1.29.0"
       }
     },
     "minimatch": {
@@ -4365,7 +4365,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4380,8 +4380,8 @@
       "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "0.1.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^0.1.1"
       }
     },
     "mkdirp": {
@@ -4422,7 +4422,7 @@
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14"
+            "readable-stream": "~1.1.9"
           }
         },
         "isarray": {
@@ -4437,10 +4437,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4469,17 +4469,17 @@
       "integrity": "sha512-ZHJamn1utzcUvW8Bais+Kk7pobp6dKmUEKOSQ/HI2glGwOMA/GvjRRKlLyORBUrdRXnwTU/6LIBcW7jYSlutgg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^1.0.0",
+        "kind-of": "^5.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4508,19 +4508,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.0.6",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.2.8",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.2.14"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -4537,24 +4537,24 @@
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.0.6",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.7.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.81.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "^2.79.0",
+        "sass-graph": "^2.1.1",
+        "stdout-stream": "^1.4.0"
       }
     },
     "node-status-codes": {
@@ -4569,7 +4569,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -4578,10 +4578,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -4590,7 +4590,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-package-arg": {
@@ -4599,8 +4599,8 @@
       "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "semver": "5.4.1"
+        "hosted-git-info": "^2.1.5",
+        "semver": "^5.1.0"
       }
     },
     "npm-run-path": {
@@ -4610,7 +4610,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -4619,10 +4619,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -4649,9 +4649,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -4660,7 +4660,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -4669,9 +4669,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -4690,7 +4690,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -4707,8 +4707,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -4717,7 +4717,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -4734,7 +4734,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4750,9 +4750,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "ordered-read-streams": {
@@ -4761,8 +4761,8 @@
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "readable-stream": "2.3.3"
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
       }
     },
     "os-filter-obj": {
@@ -4784,7 +4784,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -4799,8 +4799,8 @@
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-finally": {
@@ -4827,10 +4827,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -4845,7 +4845,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -4856,7 +4856,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -4883,7 +4883,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -4911,9 +4911,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pend": {
@@ -4946,7 +4946,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "plur": {
@@ -4955,7 +4955,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "1.4.0"
+        "irregular-plurals": "^1.0.0"
       }
     },
     "posix-character-classes": {
@@ -5019,8 +5019,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5029,7 +5029,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5038,7 +5038,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5049,7 +5049,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5060,10 +5060,10 @@
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-all-stream": {
@@ -5072,8 +5072,8 @@
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "read-pkg": {
@@ -5082,9 +5082,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -5093,8 +5093,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -5103,13 +5103,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -5118,8 +5118,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -5129,8 +5129,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regex-cache": {
@@ -5139,8 +5139,8 @@
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "^0.1.3",
+        "is-primitive": "^2.0.0"
       }
     },
     "regex-not": {
@@ -5149,7 +5149,7 @@
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -5176,7 +5176,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -5191,28 +5191,28 @@
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~4.2.1",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "performance-now": "^0.2.0",
+        "qs": "~6.4.0",
+        "safe-buffer": "^5.0.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.0.0"
       },
       "dependencies": {
         "tunnel-agent": {
@@ -5221,7 +5221,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "uuid": {
@@ -5256,8 +5256,8 @@
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "resolve-url": {
@@ -5272,8 +5272,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -5288,7 +5288,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -5309,10 +5309,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.0.6",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -5336,8 +5336,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -5346,7 +5346,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -5357,7 +5357,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       }
     },
     "semver": {
@@ -5380,7 +5380,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.3.0"
       }
     },
     "set-blocking": {
@@ -5395,7 +5395,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -5410,10 +5410,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.0.2"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       }
     },
     "shebang-command": {
@@ -5423,7 +5423,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -5451,14 +5451,14 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -5467,7 +5467,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -5476,9 +5476,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -5495,9 +5495,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -5514,7 +5514,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sntp": {
@@ -5523,7 +5523,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
@@ -5538,11 +5538,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.0.3",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -5563,7 +5563,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -5584,7 +5584,7 @@
       "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "sprintf-js": {
@@ -5600,9 +5600,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "1.1.3",
-        "console-stream": "0.1.1",
-        "lpad-align": "1.1.2"
+        "chalk": "^1.0.0",
+        "console-stream": "^0.1.1",
+        "lpad-align": "^1.0.1"
       }
     },
     "sshpk": {
@@ -5611,14 +5611,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -5647,8 +5647,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -5657,7 +5657,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -5666,9 +5666,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -5685,7 +5685,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "stream-combiner2": {
@@ -5694,8 +5694,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.3"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-shift": {
@@ -5704,24 +5704,24 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -5736,7 +5736,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -5745,7 +5745,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-stream": {
@@ -5754,8 +5754,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "strip-dirs": {
@@ -5764,12 +5764,12 @@
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "get-stdin": "4.0.1",
-        "is-absolute": "0.1.7",
-        "is-natural-number": "2.1.1",
-        "minimist": "1.2.0",
-        "sum-up": "1.0.3"
+        "chalk": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "is-absolute": "^0.1.5",
+        "is-natural-number": "^2.0.0",
+        "minimist": "^1.1.0",
+        "sum-up": "^1.0.1"
       }
     },
     "strip-eof": {
@@ -5785,7 +5785,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -5800,7 +5800,7 @@
       "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "sum-up": {
@@ -5809,7 +5809,7 @@
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "supports-color": {
@@ -5831,13 +5831,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
       },
       "dependencies": {
         "js-yaml": {
@@ -5847,8 +5847,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         }
       }
@@ -5859,9 +5859,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-stream": {
@@ -5870,10 +5870,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "temp-dir": {
@@ -5890,8 +5890,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "temp-dir": "1.0.0",
-        "uuid": "3.1.0"
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
       }
     },
     "through": {
@@ -5906,8 +5906,8 @@
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
         "isarray": {
@@ -5922,10 +5922,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5942,8 +5942,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "through2": {
@@ -5952,8 +5952,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -5976,7 +5976,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "to-object-path": {
@@ -5985,7 +5985,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -5994,9 +5994,9 @@
       "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -6005,7 +6005,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -6014,9 +6014,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -6033,8 +6033,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -6043,7 +6043,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -6054,7 +6054,7 @@
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-newlines": {
@@ -6069,7 +6069,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "tunnel-agent": {
@@ -6103,10 +6103,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -6115,10 +6115,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -6129,8 +6129,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "1.0.1",
-        "through2-filter": "2.0.0"
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
       }
     },
     "unset-value": {
@@ -6139,8 +6139,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -6149,9 +6149,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -6197,7 +6197,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-regex": {
@@ -6207,7 +6207,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ip-regex": "1.0.3"
+        "ip-regex": "^1.0.1"
       }
     },
     "use": {
@@ -6216,9 +6216,9 @@
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -6227,7 +6227,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -6236,9 +6236,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "isobject": {
@@ -6280,8 +6280,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -6290,9 +6290,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6309,8 +6309,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
@@ -6328,8 +6328,8 @@
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3"
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "vinyl-fs": {
@@ -6338,23 +6338,23 @@
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.1",
-        "glob-stream": "5.3.5",
-        "graceful-fs": "4.1.11",
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "0.3.0",
-        "lazystream": "1.0.0",
-        "lodash.isequal": "4.5.0",
-        "merge-stream": "1.0.1",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "1.0.0",
-        "through2": "2.0.3",
-        "through2-filter": "2.0.0",
-        "vali-date": "1.0.0",
-        "vinyl": "1.2.0"
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "through2": {
@@ -6363,8 +6363,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -6375,7 +6375,7 @@
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "dev": true,
       "requires": {
-        "wrap-fn": "0.1.5"
+        "wrap-fn": "^0.1.0"
       }
     },
     "whet.extend": {
@@ -6391,7 +6391,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -6406,7 +6406,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "wrap-ansi": {
@@ -6415,8 +6415,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrap-fn": {
@@ -6458,19 +6458,19 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6487,7 +6487,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6504,8 +6504,8 @@
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.0.1"
       }
     }
   }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2637,8 +2637,16 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .wp-block-image.alignfull,
 .wp-block-gallery.alignfull,
 .wp-block-text-columns.alignfull {
-  width: -webkit-calc( 100% + 15px);
-  width: calc( 100% + 15px); }
+  margin-right: -1.4%;
+  width: -webkit-calc( 102.8% + 15px);
+  width: calc( 102.8% + 15px); }
+  .wp-block-cover-image.alignfull img,
+  .wp-block-image.alignfull img,
+  .wp-block-cover-text.alignfull img,
+  .wp-block-image.alignfull img,
+  .wp-block-gallery.alignfull img,
+  .wp-block-text-columns.alignfull img {
+    width: 100%; }
   .wp-block-cover-image.alignfull figcaption,
   .wp-block-image.alignfull figcaption,
   .wp-block-cover-text.alignfull figcaption,
@@ -2661,7 +2669,10 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
     .wp-block-image.alignfull,
     .wp-block-gallery.alignfull,
     .wp-block-text-columns.alignfull {
-      width: 100%; }
+      margin-right: -webkit-calc( -1em - 1.45%);
+      margin-right: calc( -1em - 1.45%);
+      width: -webkit-calc( 102.9% + 2em);
+      width: calc( 102.9% + 2em); }
       .wp-block-cover-image.alignfull figcaption,
       .wp-block-image.alignfull figcaption,
       .wp-block-cover-text.alignfull figcaption,
@@ -2699,8 +2710,6 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .entry-content ul.alignleft,
 .entry-content ol.alignleft,
 .wp-block-cover-text.alignleft {
-  max-width: -webkit-calc( 0.4 * 1100px);
-  max-width: calc( 0.4 * 1100px);
   margin: 0 0 1.5em 1.5em; }
 
 .wp-block-image.alignright,
@@ -2711,9 +2720,68 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .entry-content ul.alignright,
 .entry-content ol.alignright,
 .wp-block-cover-text.alignright {
-  max-width: -webkit-calc( 0.4 * 1100px);
-  max-width: calc( 0.4 * 1100px);
   margin: 0 1.5em 1.5em 0; }
+
+.wp-block-image.alignleft, .wp-block-image.alignright,
+.wp-block-gallery.alignleft,
+.wp-block-gallery.alignright,
+.wp-block-video.alignleft,
+.wp-block-video.alignright,
+.wp-block-quote.alignleft,
+.wp-block-quote.alignright,
+.wp-block-text-columns.alignleft,
+.wp-block-text-columns.alignright,
+.entry-content ul.alignleft,
+.entry-content ul.alignright,
+.entry-content ol.alignleft,
+.entry-content ol.alignright,
+.wp-block-cover-text.alignleft,
+.wp-block-cover-text.alignright {
+  max-width: -webkit-calc( 0.4 * 1100px);
+  max-width: calc( 0.4 * 1100px); }
+  @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
+    .wp-block-image.alignleft, .wp-block-image.alignright,
+    .wp-block-gallery.alignleft,
+    .wp-block-gallery.alignright,
+    .wp-block-video.alignleft,
+    .wp-block-video.alignright,
+    .wp-block-quote.alignleft,
+    .wp-block-quote.alignright,
+    .wp-block-text-columns.alignleft,
+    .wp-block-text-columns.alignright,
+    .entry-content ul.alignleft,
+    .entry-content ul.alignright,
+    .entry-content ol.alignleft,
+    .entry-content ol.alignright,
+    .wp-block-cover-text.alignleft,
+    .wp-block-cover-text.alignright {
+      max-width: -webkit-calc( 0.25 * 1100px);
+      max-width: calc( 0.25 * 1100px);
+      margin-bottom: 0.5em; } }
+  @media only screen and (max-width: 40.063em) {
+    .wp-block-image.alignleft, .wp-block-image.alignright,
+    .wp-block-gallery.alignleft,
+    .wp-block-gallery.alignright,
+    .wp-block-video.alignleft,
+    .wp-block-video.alignright,
+    .wp-block-quote.alignleft,
+    .wp-block-quote.alignright,
+    .wp-block-text-columns.alignleft,
+    .wp-block-text-columns.alignright,
+    .entry-content ul.alignleft,
+    .entry-content ul.alignright,
+    .entry-content ol.alignleft,
+    .entry-content ol.alignright,
+    .wp-block-cover-text.alignleft,
+    .wp-block-cover-text.alignright {
+      max-width: 100%;
+      margin-right: 0;
+      margin-left: 0; } }
+
+.wp-block-pullquote {
+  padding: 2em 0; }
+  .wp-block-pullquote p {
+    margin: 0 0 0.25rem 0; }
 
 body.customize-support h1,
 body.customize-support h2,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2631,164 +2631,88 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 /*--------------------------------------------------------------
 >>> Gutenberg:
 --------------------------------------------------------------*/
-.wp-block-cover-image.alignfull,
-.wp-block-image.alignfull,
-.wp-block-cover-text.alignfull,
-.wp-block-image.alignfull,
-.wp-block-gallery.alignfull,
-.wp-block-text-columns.alignfull {
-  margin-right: -1.4%;
-  width: -webkit-calc( 102.8% + 15px);
-  width: calc( 102.8% + 15px); }
-  .wp-block-cover-image.alignfull img,
-  .wp-block-image.alignfull img,
-  .wp-block-cover-text.alignfull img,
-  .wp-block-image.alignfull img,
-  .wp-block-gallery.alignfull img,
-  .wp-block-text-columns.alignfull img {
+body.customize-support .wp-block-cover-image {
+  margin-bottom: 1.5rem; }
+
+body.customize-support .alignfull {
+  width: 100.5vw;
+  position: relative;
+  right: 50%;
+  left: 50%;
+  margin-right: -50vw;
+  margin-left: -50vw; }
+  @media only screen and (max-width: 40.063em) {
+    body.customize-support .alignfull {
+      width: 100vw; } }
+  body.customize-support .alignfull img {
     width: 100%; }
-  .wp-block-cover-image.alignfull figcaption,
-  .wp-block-image.alignfull figcaption,
-  .wp-block-cover-text.alignfull figcaption,
-  .wp-block-image.alignfull figcaption,
-  .wp-block-gallery.alignfull figcaption,
-  .wp-block-text-columns.alignfull figcaption {
-    padding: 0 3.375em; }
-  @media only screen and (max-width: 61.063em) {
-    .wp-block-cover-image.alignfull figcaption,
-    .wp-block-image.alignfull figcaption,
-    .wp-block-cover-text.alignfull figcaption,
-    .wp-block-image.alignfull figcaption,
-    .wp-block-gallery.alignfull figcaption,
-    .wp-block-text-columns.alignfull figcaption {
-      padding: 0 2.375em; } }
-  @media only screen and (max-width: 40.063em) {
-    .wp-block-cover-image.alignfull,
-    .wp-block-image.alignfull,
-    .wp-block-cover-text.alignfull,
-    .wp-block-image.alignfull,
-    .wp-block-gallery.alignfull,
-    .wp-block-text-columns.alignfull {
-      margin-right: -webkit-calc( -1em - 1.45%);
-      margin-right: calc( -1em - 1.45%);
-      width: -webkit-calc( 102.9% + 2em);
-      width: calc( 102.9% + 2em); }
-      .wp-block-cover-image.alignfull figcaption,
-      .wp-block-image.alignfull figcaption,
-      .wp-block-cover-text.alignfull figcaption,
-      .wp-block-image.alignfull figcaption,
-      .wp-block-gallery.alignfull figcaption,
-      .wp-block-text-columns.alignfull figcaption {
-        padding: 0 1em; } }
 
-.wp-block-cover-image.alignwide,
-.wp-block-image.alignwide,
-.wp-block-cover-text.alignwide,
-.wp-block-image.alignwide,
-.wp-block-gallery.alignwide,
-.wp-block-text-columns.alignwide {
-  margin-right: -1.6875em;
-  margin-left: -1.6875em;
-  width: -webkit-calc( 100% + 3.375em);
-  width: calc( 100% + 3.375em); }
-  @media only screen and (max-width: 40.063em) {
-    .wp-block-cover-image.alignwide,
-    .wp-block-image.alignwide,
-    .wp-block-cover-text.alignwide,
-    .wp-block-image.alignwide,
-    .wp-block-gallery.alignwide,
-    .wp-block-text-columns.alignwide {
-      margin-right: -1.5em;
-      width: -webkit-calc( 100% + 3em);
-      width: calc( 100% + 3em); } }
-
-.wp-block-image.alignleft,
-.wp-block-gallery.alignleft,
-.wp-block-video.alignleft,
-.wp-block-quote.alignleft,
-.wp-block-text-columns.alignleft,
-.entry-content ul.alignleft,
-.entry-content ol.alignleft,
-.wp-block-cover-text.alignleft {
-  margin: 0 0 1.5em 1.5em; }
-
-.wp-block-image.alignright,
-.wp-block-gallery.alignright,
-.wp-block-video.alignright,
-.wp-block-quote.alignright,
-.wp-block-text-columns.alignright,
-.entry-content ul.alignright,
-.entry-content ol.alignright,
-.wp-block-cover-text.alignright {
-  margin: 0 1.5em 1.5em 0; }
-
-.wp-block-image.alignleft, .wp-block-image.alignright,
-.wp-block-gallery.alignleft,
-.wp-block-gallery.alignright,
-.wp-block-video.alignleft,
-.wp-block-video.alignright,
-.wp-block-quote.alignleft,
-.wp-block-quote.alignright,
-.wp-block-text-columns.alignleft,
-.wp-block-text-columns.alignright,
-.entry-content ul.alignleft,
-.entry-content ul.alignright,
-.entry-content ol.alignleft,
-.entry-content ol.alignright,
-.wp-block-cover-text.alignleft,
-.wp-block-cover-text.alignright {
-  max-width: -webkit-calc( 0.4 * 1100px);
-  max-width: calc( 0.4 * 1100px); }
+body.customize-support .alignwide {
+  margin-right: -1.5%;
+  margin-left: -1.5%;
+  width: 102%; }
   @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
-    .wp-block-image.alignleft, .wp-block-image.alignright,
-    .wp-block-gallery.alignleft,
-    .wp-block-gallery.alignright,
-    .wp-block-video.alignleft,
-    .wp-block-video.alignright,
-    .wp-block-quote.alignleft,
-    .wp-block-quote.alignright,
-    .wp-block-text-columns.alignleft,
-    .wp-block-text-columns.alignright,
-    .entry-content ul.alignleft,
-    .entry-content ul.alignright,
-    .entry-content ol.alignleft,
-    .entry-content ol.alignright,
-    .wp-block-cover-text.alignleft,
-    .wp-block-cover-text.alignright {
-      max-width: -webkit-calc( 0.25 * 1100px);
-      max-width: calc( 0.25 * 1100px);
-      margin-bottom: 0.5em; } }
-  @media only screen and (max-width: 40.063em) {
-    .wp-block-image.alignleft, .wp-block-image.alignright,
-    .wp-block-gallery.alignleft,
-    .wp-block-gallery.alignright,
-    .wp-block-video.alignleft,
-    .wp-block-video.alignright,
-    .wp-block-quote.alignleft,
-    .wp-block-quote.alignright,
-    .wp-block-text-columns.alignleft,
-    .wp-block-text-columns.alignright,
-    .entry-content ul.alignleft,
-    .entry-content ul.alignright,
-    .entry-content ol.alignleft,
-    .entry-content ol.alignright,
-    .wp-block-cover-text.alignleft,
-    .wp-block-cover-text.alignright {
-      max-width: 100%;
-      margin-right: 0;
-      margin-left: 0; } }
+    body.customize-support .alignwide {
+      margin-right: -1.25%;
+      margin-left: -1.25%;
+      width: 102.5%; } }
 
-.wp-block-pullquote {
-  padding: 2em 0; }
-  .wp-block-pullquote p {
-    margin: 0 0 0.25rem 0; }
+body.customize-support .wp-block-image.alignleft,
+body.customize-support .wp-block-gallery.alignleft,
+body.customize-support .wp-block-video.alignleft,
+body.customize-support .wp-block-quote.alignleft,
+body.customize-support .wp-block-text-columns.alignleft,
+body.customize-support .entry-content ul.alignleft,
+body.customize-support .entry-content ol.alignleft,
+body.customize-support .wp-block-cover-text.alignleft {
+  margin: 0 0 0.5em 1em; }
 
-body.customize-support h1,
-body.customize-support h2,
-body.customize-support h3,
-body.customize-support h4,
-body.customize-support h5,
-body.customize-support h6,
-body.customize-support .site-title,
-body.customize-support .page-title {
-  clear: none; }
+body.customize-support .wp-block-image.alignright,
+body.customize-support .wp-block-gallery.alignright,
+body.customize-support .wp-block-video.alignright,
+body.customize-support .wp-block-quote.alignright,
+body.customize-support .wp-block-text-columns.alignright,
+body.customize-support .entry-content ul.alignright,
+body.customize-support .entry-content ol.alignright,
+body.customize-support .wp-block-cover-text.alignright {
+  margin: 0 1em 0.5em 0; }
+
+body.customize-support .wp-block-image.alignleft, body.customize-support .wp-block-image.alignright,
+body.customize-support .wp-block-gallery.alignleft,
+body.customize-support .wp-block-gallery.alignright,
+body.customize-support .wp-block-video.alignleft,
+body.customize-support .wp-block-video.alignright,
+body.customize-support .wp-block-quote.alignleft,
+body.customize-support .wp-block-quote.alignright,
+body.customize-support .wp-block-text-columns.alignleft,
+body.customize-support .wp-block-text-columns.alignright,
+body.customize-support .entry-content ul.alignleft,
+body.customize-support .entry-content ul.alignright,
+body.customize-support .entry-content ol.alignleft,
+body.customize-support .entry-content ol.alignright,
+body.customize-support .wp-block-cover-text.alignleft,
+body.customize-support .wp-block-cover-text.alignright {
+  max-width: 40%;
+  width: 100%; }
+  body.customize-support .wp-block-image.alignleft img, body.customize-support .wp-block-image.alignright img,
+  body.customize-support .wp-block-gallery.alignleft img,
+  body.customize-support .wp-block-gallery.alignright img,
+  body.customize-support .wp-block-video.alignleft img,
+  body.customize-support .wp-block-video.alignright img,
+  body.customize-support .wp-block-quote.alignleft img,
+  body.customize-support .wp-block-quote.alignright img,
+  body.customize-support .wp-block-text-columns.alignleft img,
+  body.customize-support .wp-block-text-columns.alignright img,
+  body.customize-support .entry-content ul.alignleft img,
+  body.customize-support .entry-content ul.alignright img,
+  body.customize-support .entry-content ol.alignleft img,
+  body.customize-support .entry-content ol.alignright img,
+  body.customize-support .wp-block-cover-text.alignleft img,
+  body.customize-support .wp-block-cover-text.alignright img {
+    width: inherit; }
+
+body.customize-support .wp-block-gallery {
+  margin-right: 0;
+  margin-left: 0; }
+  body.customize-support .wp-block-gallery.is-cropped .blocks-gallery-item img {
+    height: auto; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2627,3 +2627,100 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%; } }
+
+/*--------------------------------------------------------------
+>>> Gutenberg:
+--------------------------------------------------------------*/
+.wp-block-cover-image.alignfull,
+.wp-block-image.alignfull,
+.wp-block-cover-text.alignfull,
+.wp-block-image.alignfull,
+.wp-block-gallery.alignfull,
+.wp-block-text-columns.alignfull {
+  width: -webkit-calc( 100% + 15px);
+  width: calc( 100% + 15px); }
+  .wp-block-cover-image.alignfull figcaption,
+  .wp-block-image.alignfull figcaption,
+  .wp-block-cover-text.alignfull figcaption,
+  .wp-block-image.alignfull figcaption,
+  .wp-block-gallery.alignfull figcaption,
+  .wp-block-text-columns.alignfull figcaption {
+    padding: 0 3.375em; }
+  @media only screen and (max-width: 61.063em) {
+    .wp-block-cover-image.alignfull figcaption,
+    .wp-block-image.alignfull figcaption,
+    .wp-block-cover-text.alignfull figcaption,
+    .wp-block-image.alignfull figcaption,
+    .wp-block-gallery.alignfull figcaption,
+    .wp-block-text-columns.alignfull figcaption {
+      padding: 0 2.375em; } }
+  @media only screen and (max-width: 40.063em) {
+    .wp-block-cover-image.alignfull,
+    .wp-block-image.alignfull,
+    .wp-block-cover-text.alignfull,
+    .wp-block-image.alignfull,
+    .wp-block-gallery.alignfull,
+    .wp-block-text-columns.alignfull {
+      width: 100%; }
+      .wp-block-cover-image.alignfull figcaption,
+      .wp-block-image.alignfull figcaption,
+      .wp-block-cover-text.alignfull figcaption,
+      .wp-block-image.alignfull figcaption,
+      .wp-block-gallery.alignfull figcaption,
+      .wp-block-text-columns.alignfull figcaption {
+        padding: 0 1em; } }
+
+.wp-block-cover-image.alignwide,
+.wp-block-image.alignwide,
+.wp-block-cover-text.alignwide,
+.wp-block-image.alignwide,
+.wp-block-gallery.alignwide,
+.wp-block-text-columns.alignwide {
+  margin-right: -1.6875em;
+  margin-left: -1.6875em;
+  width: -webkit-calc( 100% + 3.375em);
+  width: calc( 100% + 3.375em); }
+  @media only screen and (max-width: 40.063em) {
+    .wp-block-cover-image.alignwide,
+    .wp-block-image.alignwide,
+    .wp-block-cover-text.alignwide,
+    .wp-block-image.alignwide,
+    .wp-block-gallery.alignwide,
+    .wp-block-text-columns.alignwide {
+      margin-right: -1.5em;
+      width: -webkit-calc( 100% + 3em);
+      width: calc( 100% + 3em); } }
+
+.wp-block-image.alignleft,
+.wp-block-gallery.alignleft,
+.wp-block-video.alignleft,
+.wp-block-quote.alignleft,
+.wp-block-text-columns.alignleft,
+.entry-content ul.alignleft,
+.entry-content ol.alignleft,
+.wp-block-cover-text.alignleft {
+  max-width: -webkit-calc( 0.4 * 1100px);
+  max-width: calc( 0.4 * 1100px);
+  margin: 0 0 1.5em 1.5em; }
+
+.wp-block-image.alignright,
+.wp-block-gallery.alignright,
+.wp-block-video.alignright,
+.wp-block-quote.alignright,
+.wp-block-text-columns.alignright,
+.entry-content ul.alignright,
+.entry-content ol.alignright,
+.wp-block-cover-text.alignright {
+  max-width: -webkit-calc( 0.4 * 1100px);
+  max-width: calc( 0.4 * 1100px);
+  margin: 0 1.5em 1.5em 0; }
+
+body.customize-support h1,
+body.customize-support h2,
+body.customize-support h3,
+body.customize-support h4,
+body.customize-support h5,
+body.customize-support h6,
+body.customize-support .site-title,
+body.customize-support .page-title {
+  clear: none; }

--- a/style.css
+++ b/style.css
@@ -2631,164 +2631,88 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 /*--------------------------------------------------------------
 >>> Gutenberg:
 --------------------------------------------------------------*/
-.wp-block-cover-image.alignfull,
-.wp-block-image.alignfull,
-.wp-block-cover-text.alignfull,
-.wp-block-image.alignfull,
-.wp-block-gallery.alignfull,
-.wp-block-text-columns.alignfull {
-  margin-left: -1.4%;
-  width: -webkit-calc( 102.8% + 15px);
-  width: calc( 102.8% + 15px); }
-  .wp-block-cover-image.alignfull img,
-  .wp-block-image.alignfull img,
-  .wp-block-cover-text.alignfull img,
-  .wp-block-image.alignfull img,
-  .wp-block-gallery.alignfull img,
-  .wp-block-text-columns.alignfull img {
+body.customize-support .wp-block-cover-image {
+  margin-bottom: 1.5rem; }
+
+body.customize-support .alignfull {
+  width: 100.5vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw; }
+  @media only screen and (max-width: 40.063em) {
+    body.customize-support .alignfull {
+      width: 100vw; } }
+  body.customize-support .alignfull img {
     width: 100%; }
-  .wp-block-cover-image.alignfull figcaption,
-  .wp-block-image.alignfull figcaption,
-  .wp-block-cover-text.alignfull figcaption,
-  .wp-block-image.alignfull figcaption,
-  .wp-block-gallery.alignfull figcaption,
-  .wp-block-text-columns.alignfull figcaption {
-    padding: 0 3.375em; }
-  @media only screen and (max-width: 61.063em) {
-    .wp-block-cover-image.alignfull figcaption,
-    .wp-block-image.alignfull figcaption,
-    .wp-block-cover-text.alignfull figcaption,
-    .wp-block-image.alignfull figcaption,
-    .wp-block-gallery.alignfull figcaption,
-    .wp-block-text-columns.alignfull figcaption {
-      padding: 0 2.375em; } }
-  @media only screen and (max-width: 40.063em) {
-    .wp-block-cover-image.alignfull,
-    .wp-block-image.alignfull,
-    .wp-block-cover-text.alignfull,
-    .wp-block-image.alignfull,
-    .wp-block-gallery.alignfull,
-    .wp-block-text-columns.alignfull {
-      margin-left: -webkit-calc( -1em - 1.45%);
-      margin-left: calc( -1em - 1.45%);
-      width: -webkit-calc( 102.9% + 2em);
-      width: calc( 102.9% + 2em); }
-      .wp-block-cover-image.alignfull figcaption,
-      .wp-block-image.alignfull figcaption,
-      .wp-block-cover-text.alignfull figcaption,
-      .wp-block-image.alignfull figcaption,
-      .wp-block-gallery.alignfull figcaption,
-      .wp-block-text-columns.alignfull figcaption {
-        padding: 0 1em; } }
 
-.wp-block-cover-image.alignwide,
-.wp-block-image.alignwide,
-.wp-block-cover-text.alignwide,
-.wp-block-image.alignwide,
-.wp-block-gallery.alignwide,
-.wp-block-text-columns.alignwide {
-  margin-left: -1.6875em;
-  margin-right: -1.6875em;
-  width: -webkit-calc( 100% + 3.375em);
-  width: calc( 100% + 3.375em); }
-  @media only screen and (max-width: 40.063em) {
-    .wp-block-cover-image.alignwide,
-    .wp-block-image.alignwide,
-    .wp-block-cover-text.alignwide,
-    .wp-block-image.alignwide,
-    .wp-block-gallery.alignwide,
-    .wp-block-text-columns.alignwide {
-      margin-left: -1.5em;
-      width: -webkit-calc( 100% + 3em);
-      width: calc( 100% + 3em); } }
-
-.wp-block-image.alignleft,
-.wp-block-gallery.alignleft,
-.wp-block-video.alignleft,
-.wp-block-quote.alignleft,
-.wp-block-text-columns.alignleft,
-.entry-content ul.alignleft,
-.entry-content ol.alignleft,
-.wp-block-cover-text.alignleft {
-  margin: 0 1.5em 1.5em 0; }
-
-.wp-block-image.alignright,
-.wp-block-gallery.alignright,
-.wp-block-video.alignright,
-.wp-block-quote.alignright,
-.wp-block-text-columns.alignright,
-.entry-content ul.alignright,
-.entry-content ol.alignright,
-.wp-block-cover-text.alignright {
-  margin: 0 0 1.5em 1.5em; }
-
-.wp-block-image.alignleft, .wp-block-image.alignright,
-.wp-block-gallery.alignleft,
-.wp-block-gallery.alignright,
-.wp-block-video.alignleft,
-.wp-block-video.alignright,
-.wp-block-quote.alignleft,
-.wp-block-quote.alignright,
-.wp-block-text-columns.alignleft,
-.wp-block-text-columns.alignright,
-.entry-content ul.alignleft,
-.entry-content ul.alignright,
-.entry-content ol.alignleft,
-.entry-content ol.alignright,
-.wp-block-cover-text.alignleft,
-.wp-block-cover-text.alignright {
-  max-width: -webkit-calc( 0.4 * 1100px);
-  max-width: calc( 0.4 * 1100px); }
+body.customize-support .alignwide {
+  margin-left: -1.5%;
+  margin-right: -1.5%;
+  width: 102%; }
   @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
-    .wp-block-image.alignleft, .wp-block-image.alignright,
-    .wp-block-gallery.alignleft,
-    .wp-block-gallery.alignright,
-    .wp-block-video.alignleft,
-    .wp-block-video.alignright,
-    .wp-block-quote.alignleft,
-    .wp-block-quote.alignright,
-    .wp-block-text-columns.alignleft,
-    .wp-block-text-columns.alignright,
-    .entry-content ul.alignleft,
-    .entry-content ul.alignright,
-    .entry-content ol.alignleft,
-    .entry-content ol.alignright,
-    .wp-block-cover-text.alignleft,
-    .wp-block-cover-text.alignright {
-      max-width: -webkit-calc( 0.25 * 1100px);
-      max-width: calc( 0.25 * 1100px);
-      margin-bottom: 0.5em; } }
-  @media only screen and (max-width: 40.063em) {
-    .wp-block-image.alignleft, .wp-block-image.alignright,
-    .wp-block-gallery.alignleft,
-    .wp-block-gallery.alignright,
-    .wp-block-video.alignleft,
-    .wp-block-video.alignright,
-    .wp-block-quote.alignleft,
-    .wp-block-quote.alignright,
-    .wp-block-text-columns.alignleft,
-    .wp-block-text-columns.alignright,
-    .entry-content ul.alignleft,
-    .entry-content ul.alignright,
-    .entry-content ol.alignleft,
-    .entry-content ol.alignright,
-    .wp-block-cover-text.alignleft,
-    .wp-block-cover-text.alignright {
-      max-width: 100%;
-      margin-left: 0;
-      margin-right: 0; } }
+    body.customize-support .alignwide {
+      margin-left: -1.25%;
+      margin-right: -1.25%;
+      width: 102.5%; } }
 
-.wp-block-pullquote {
-  padding: 2em 0; }
-  .wp-block-pullquote p {
-    margin: 0 0 0.25rem 0; }
+body.customize-support .wp-block-image.alignleft,
+body.customize-support .wp-block-gallery.alignleft,
+body.customize-support .wp-block-video.alignleft,
+body.customize-support .wp-block-quote.alignleft,
+body.customize-support .wp-block-text-columns.alignleft,
+body.customize-support .entry-content ul.alignleft,
+body.customize-support .entry-content ol.alignleft,
+body.customize-support .wp-block-cover-text.alignleft {
+  margin: 0 1em 0.5em 0; }
 
-body.customize-support h1,
-body.customize-support h2,
-body.customize-support h3,
-body.customize-support h4,
-body.customize-support h5,
-body.customize-support h6,
-body.customize-support .site-title,
-body.customize-support .page-title {
-  clear: none; }
+body.customize-support .wp-block-image.alignright,
+body.customize-support .wp-block-gallery.alignright,
+body.customize-support .wp-block-video.alignright,
+body.customize-support .wp-block-quote.alignright,
+body.customize-support .wp-block-text-columns.alignright,
+body.customize-support .entry-content ul.alignright,
+body.customize-support .entry-content ol.alignright,
+body.customize-support .wp-block-cover-text.alignright {
+  margin: 0 0 0.5em 1em; }
+
+body.customize-support .wp-block-image.alignleft, body.customize-support .wp-block-image.alignright,
+body.customize-support .wp-block-gallery.alignleft,
+body.customize-support .wp-block-gallery.alignright,
+body.customize-support .wp-block-video.alignleft,
+body.customize-support .wp-block-video.alignright,
+body.customize-support .wp-block-quote.alignleft,
+body.customize-support .wp-block-quote.alignright,
+body.customize-support .wp-block-text-columns.alignleft,
+body.customize-support .wp-block-text-columns.alignright,
+body.customize-support .entry-content ul.alignleft,
+body.customize-support .entry-content ul.alignright,
+body.customize-support .entry-content ol.alignleft,
+body.customize-support .entry-content ol.alignright,
+body.customize-support .wp-block-cover-text.alignleft,
+body.customize-support .wp-block-cover-text.alignright {
+  max-width: 40%;
+  width: 100%; }
+  body.customize-support .wp-block-image.alignleft img, body.customize-support .wp-block-image.alignright img,
+  body.customize-support .wp-block-gallery.alignleft img,
+  body.customize-support .wp-block-gallery.alignright img,
+  body.customize-support .wp-block-video.alignleft img,
+  body.customize-support .wp-block-video.alignright img,
+  body.customize-support .wp-block-quote.alignleft img,
+  body.customize-support .wp-block-quote.alignright img,
+  body.customize-support .wp-block-text-columns.alignleft img,
+  body.customize-support .wp-block-text-columns.alignright img,
+  body.customize-support .entry-content ul.alignleft img,
+  body.customize-support .entry-content ul.alignright img,
+  body.customize-support .entry-content ol.alignleft img,
+  body.customize-support .entry-content ol.alignright img,
+  body.customize-support .wp-block-cover-text.alignleft img,
+  body.customize-support .wp-block-cover-text.alignright img {
+    width: inherit; }
+
+body.customize-support .wp-block-gallery {
+  margin-left: 0;
+  margin-right: 0; }
+  body.customize-support .wp-block-gallery.is-cropped .blocks-gallery-item img {
+    height: auto; }

--- a/style.css
+++ b/style.css
@@ -2637,8 +2637,16 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .wp-block-image.alignfull,
 .wp-block-gallery.alignfull,
 .wp-block-text-columns.alignfull {
-  width: -webkit-calc( 100% + 15px);
-  width: calc( 100% + 15px); }
+  margin-left: -1.4%;
+  width: -webkit-calc( 102.8% + 15px);
+  width: calc( 102.8% + 15px); }
+  .wp-block-cover-image.alignfull img,
+  .wp-block-image.alignfull img,
+  .wp-block-cover-text.alignfull img,
+  .wp-block-image.alignfull img,
+  .wp-block-gallery.alignfull img,
+  .wp-block-text-columns.alignfull img {
+    width: 100%; }
   .wp-block-cover-image.alignfull figcaption,
   .wp-block-image.alignfull figcaption,
   .wp-block-cover-text.alignfull figcaption,
@@ -2661,7 +2669,10 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
     .wp-block-image.alignfull,
     .wp-block-gallery.alignfull,
     .wp-block-text-columns.alignfull {
-      width: 100%; }
+      margin-left: -webkit-calc( -1em - 1.45%);
+      margin-left: calc( -1em - 1.45%);
+      width: -webkit-calc( 102.9% + 2em);
+      width: calc( 102.9% + 2em); }
       .wp-block-cover-image.alignfull figcaption,
       .wp-block-image.alignfull figcaption,
       .wp-block-cover-text.alignfull figcaption,
@@ -2699,8 +2710,6 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .entry-content ul.alignleft,
 .entry-content ol.alignleft,
 .wp-block-cover-text.alignleft {
-  max-width: -webkit-calc( 0.4 * 1100px);
-  max-width: calc( 0.4 * 1100px);
   margin: 0 1.5em 1.5em 0; }
 
 .wp-block-image.alignright,
@@ -2711,9 +2720,68 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .entry-content ul.alignright,
 .entry-content ol.alignright,
 .wp-block-cover-text.alignright {
-  max-width: -webkit-calc( 0.4 * 1100px);
-  max-width: calc( 0.4 * 1100px);
   margin: 0 0 1.5em 1.5em; }
+
+.wp-block-image.alignleft, .wp-block-image.alignright,
+.wp-block-gallery.alignleft,
+.wp-block-gallery.alignright,
+.wp-block-video.alignleft,
+.wp-block-video.alignright,
+.wp-block-quote.alignleft,
+.wp-block-quote.alignright,
+.wp-block-text-columns.alignleft,
+.wp-block-text-columns.alignright,
+.entry-content ul.alignleft,
+.entry-content ul.alignright,
+.entry-content ol.alignleft,
+.entry-content ol.alignright,
+.wp-block-cover-text.alignleft,
+.wp-block-cover-text.alignright {
+  max-width: -webkit-calc( 0.4 * 1100px);
+  max-width: calc( 0.4 * 1100px); }
+  @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
+    .wp-block-image.alignleft, .wp-block-image.alignright,
+    .wp-block-gallery.alignleft,
+    .wp-block-gallery.alignright,
+    .wp-block-video.alignleft,
+    .wp-block-video.alignright,
+    .wp-block-quote.alignleft,
+    .wp-block-quote.alignright,
+    .wp-block-text-columns.alignleft,
+    .wp-block-text-columns.alignright,
+    .entry-content ul.alignleft,
+    .entry-content ul.alignright,
+    .entry-content ol.alignleft,
+    .entry-content ol.alignright,
+    .wp-block-cover-text.alignleft,
+    .wp-block-cover-text.alignright {
+      max-width: -webkit-calc( 0.25 * 1100px);
+      max-width: calc( 0.25 * 1100px);
+      margin-bottom: 0.5em; } }
+  @media only screen and (max-width: 40.063em) {
+    .wp-block-image.alignleft, .wp-block-image.alignright,
+    .wp-block-gallery.alignleft,
+    .wp-block-gallery.alignright,
+    .wp-block-video.alignleft,
+    .wp-block-video.alignright,
+    .wp-block-quote.alignleft,
+    .wp-block-quote.alignright,
+    .wp-block-text-columns.alignleft,
+    .wp-block-text-columns.alignright,
+    .entry-content ul.alignleft,
+    .entry-content ul.alignright,
+    .entry-content ol.alignleft,
+    .entry-content ol.alignright,
+    .wp-block-cover-text.alignleft,
+    .wp-block-cover-text.alignright {
+      max-width: 100%;
+      margin-left: 0;
+      margin-right: 0; } }
+
+.wp-block-pullquote {
+  padding: 2em 0; }
+  .wp-block-pullquote p {
+    margin: 0 0 0.25rem 0; }
 
 body.customize-support h1,
 body.customize-support h2,

--- a/style.css
+++ b/style.css
@@ -2627,3 +2627,100 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%; } }
+
+/*--------------------------------------------------------------
+>>> Gutenberg:
+--------------------------------------------------------------*/
+.wp-block-cover-image.alignfull,
+.wp-block-image.alignfull,
+.wp-block-cover-text.alignfull,
+.wp-block-image.alignfull,
+.wp-block-gallery.alignfull,
+.wp-block-text-columns.alignfull {
+  width: -webkit-calc( 100% + 15px);
+  width: calc( 100% + 15px); }
+  .wp-block-cover-image.alignfull figcaption,
+  .wp-block-image.alignfull figcaption,
+  .wp-block-cover-text.alignfull figcaption,
+  .wp-block-image.alignfull figcaption,
+  .wp-block-gallery.alignfull figcaption,
+  .wp-block-text-columns.alignfull figcaption {
+    padding: 0 3.375em; }
+  @media only screen and (max-width: 61.063em) {
+    .wp-block-cover-image.alignfull figcaption,
+    .wp-block-image.alignfull figcaption,
+    .wp-block-cover-text.alignfull figcaption,
+    .wp-block-image.alignfull figcaption,
+    .wp-block-gallery.alignfull figcaption,
+    .wp-block-text-columns.alignfull figcaption {
+      padding: 0 2.375em; } }
+  @media only screen and (max-width: 40.063em) {
+    .wp-block-cover-image.alignfull,
+    .wp-block-image.alignfull,
+    .wp-block-cover-text.alignfull,
+    .wp-block-image.alignfull,
+    .wp-block-gallery.alignfull,
+    .wp-block-text-columns.alignfull {
+      width: 100%; }
+      .wp-block-cover-image.alignfull figcaption,
+      .wp-block-image.alignfull figcaption,
+      .wp-block-cover-text.alignfull figcaption,
+      .wp-block-image.alignfull figcaption,
+      .wp-block-gallery.alignfull figcaption,
+      .wp-block-text-columns.alignfull figcaption {
+        padding: 0 1em; } }
+
+.wp-block-cover-image.alignwide,
+.wp-block-image.alignwide,
+.wp-block-cover-text.alignwide,
+.wp-block-image.alignwide,
+.wp-block-gallery.alignwide,
+.wp-block-text-columns.alignwide {
+  margin-left: -1.6875em;
+  margin-right: -1.6875em;
+  width: -webkit-calc( 100% + 3.375em);
+  width: calc( 100% + 3.375em); }
+  @media only screen and (max-width: 40.063em) {
+    .wp-block-cover-image.alignwide,
+    .wp-block-image.alignwide,
+    .wp-block-cover-text.alignwide,
+    .wp-block-image.alignwide,
+    .wp-block-gallery.alignwide,
+    .wp-block-text-columns.alignwide {
+      margin-left: -1.5em;
+      width: -webkit-calc( 100% + 3em);
+      width: calc( 100% + 3em); } }
+
+.wp-block-image.alignleft,
+.wp-block-gallery.alignleft,
+.wp-block-video.alignleft,
+.wp-block-quote.alignleft,
+.wp-block-text-columns.alignleft,
+.entry-content ul.alignleft,
+.entry-content ol.alignleft,
+.wp-block-cover-text.alignleft {
+  max-width: -webkit-calc( 0.4 * 1100px);
+  max-width: calc( 0.4 * 1100px);
+  margin: 0 1.5em 1.5em 0; }
+
+.wp-block-image.alignright,
+.wp-block-gallery.alignright,
+.wp-block-video.alignright,
+.wp-block-quote.alignright,
+.wp-block-text-columns.alignright,
+.entry-content ul.alignright,
+.entry-content ol.alignright,
+.wp-block-cover-text.alignright {
+  max-width: -webkit-calc( 0.4 * 1100px);
+  max-width: calc( 0.4 * 1100px);
+  margin: 0 0 1.5em 1.5em; }
+
+body.customize-support h1,
+body.customize-support h2,
+body.customize-support h3,
+body.customize-support h4,
+body.customize-support h5,
+body.customize-support h6,
+body.customize-support .site-title,
+body.customize-support .page-title {
+  clear: none; }


### PR DESCRIPTION
Build in support for the [Gutenberg](https://wordpress.org/plugins/gutenberg/) page builder set to hit core in the coming months.