### PR TITLE
Tweak site title wrapper width

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -61,13 +61,12 @@ body.custom-header-image {
 
 .site-title-wrapper {
 	padding: 20px 0 0 20px;
-	width: 80%;
+	width: auto;
 	float: left;
 
 	@media #{$medium-up} {
 		padding-top: 0;
 		text-align: left;
-		width: 100%;
 	}
 
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1665,13 +1665,12 @@ body.custom-header-image .site-description {
 
 .site-title-wrapper {
   padding: 20px 20px 0 0;
-  width: 80%;
+  width: auto;
   float: right; }
   @media only screen and (min-width: 40.063em) {
     .site-title-wrapper {
       padding-top: 0;
-      text-align: right;
-      width: 100%; } }
+      text-align: right; } }
 
 .site-title {
   text-transform: uppercase;

--- a/style.css
+++ b/style.css
@@ -1665,13 +1665,12 @@ body.custom-header-image .site-description {
 
 .site-title-wrapper {
   padding: 20px 0 0 20px;
-  width: 80%;
+  width: auto;
   float: left; }
   @media only screen and (min-width: 40.063em) {
     .site-title-wrapper {
       padding-top: 0;
-      text-align: left;
-      width: 100%; } }
+      text-align: left; } }
 
 .site-title {
   text-transform: uppercase;


### PR DESCRIPTION
Resolves #56 

The width of the element `.site-title-wrapper` (logo or site title + tagline) was causing the navigation to drop down, even when the logo and/or title + tagline was not long enough to warrant it.

**Before:**
![Example Before](https://cldup.com/YZpXNLOAz4.png)

**After:**
![Example After](https://cldup.com/TmCdfJlWQw.png)

**Long Site Title/Tagline Test:**
![Example Long Site Title/Tagline](https://cldup.com/E5Cvx_-xbt.png)